### PR TITLE
feat: new tool - find long files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,20 +91,21 @@ See below for various environment variables you can set to configure specific fe
 
 ## Available Tools
 
-| Tool                                                             | Purpose                          | Dependencies                  | Quick Example                    |
-|------------------------------------------------------------------|----------------------------------|-------------------------------|----------------------------------|
-| **[Web Fetch](docs/tools/web-fetch.md)**                         | Retrieve web content as Markdown | None                          | Documentation and articles       |
-| **[Internet Search](docs/tools/internet-search.md)**             | Multi-provider web search        | None (Provider keys optional) | Web, image, news, video search   |
-| **[Package Search](docs/tools/package-search.md)**               | Check package versions           | None                          | NPM, Python, Go, Java, Docker    |
-| **[Package Documentation](docs/tools/package-documentation.md)** | Library documentation lookup     | None                          | React, Django, TensorFlow docs   |
-| **[PDF Processing](docs/tools/pdf-processing.md)**               | Fast PDF text extraction         | None                          | Quick PDF to Markdown            |
-| **[Document Processing](docs/tools/document-processing.md)**     | Convert documents to Markdown    | `pip install -U docling`      | PDF, DOCX → Markdown with OCR    |
-| **[Think](docs/tools/think.md)**                                 | Structured reasoning space       | None                          | Complex problem analysis         |
-| **[Memory](docs/tools/memory.md)**                               | Persistent knowledge graphs      | None                          | Store entities and relationships |
-| **[ShadCN UI](docs/tools/shadcn-ui.md)**                         | Component information            | None                          | Button, Dialog, Form components  |
-| **[American→English](docs/tools/american-to-english.md)**        | Convert to British spelling      | None                          | Organise, colour, centre         |
-| **[GitHub](docs/tools/github.md)**                               | GitHub repositories and data     | None (GitHub token optional)  | Issues, PRs, repos, cloning      |
-| **[Filesystem](docs/tools/filesystem.md)**                       | File and directory operations    | `FILESYSTEM_TOOL_ENABLE=true` | Read, write, edit, search files  |
+| Tool                                                             | Purpose                            | Dependencies                  | Quick Example                    |
+|------------------------------------------------------------------|------------------------------------|-------------------------------|----------------------------------|
+| **[Web Fetch](docs/tools/web-fetch.md)**                         | Retrieve web content as Markdown   | None                          | Documentation and articles       |
+| **[Internet Search](docs/tools/internet-search.md)**             | Multi-provider web search          | None (Provider keys optional) | Web, image, news, video search   |
+| **[Package Search](docs/tools/package-search.md)**               | Check package versions             | None                          | NPM, Python, Go, Java, Docker    |
+| **[Package Documentation](docs/tools/package-documentation.md)** | Library documentation lookup       | None                          | React, Django, TensorFlow docs   |
+| **[PDF Processing](docs/tools/pdf-processing.md)**               | Fast PDF text extraction           | None                          | Quick PDF to Markdown            |
+| **[Document Processing](docs/tools/document-processing.md)**     | Convert documents to Markdown      | `pip install -U docling`      | PDF, DOCX → Markdown with OCR    |
+| **[Think](docs/tools/think.md)**                                 | Structured reasoning space         | None                          | Complex problem analysis         |
+| **[Memory](docs/tools/memory.md)**                               | Persistent knowledge graphs        | None                          | Store entities and relationships |
+| **[ShadCN UI](docs/tools/shadcn-ui.md)**                         | Component information              | None                          | Button, Dialog, Form components  |
+| **[American→English](docs/tools/american-to-english.md)**        | Convert to British spelling        | None                          | Organise, colour, centre         |
+| **[GitHub](docs/tools/github.md)**                               | GitHub repositories and data       | None (GitHub token optional)  | Issues, PRs, repos, cloning      |
+| **[Find Long Files](docs/tools/find_long_files.md)**             | Identify files needing refactoring | None                          | Find files over 700 lines        |
+| **[Filesystem](docs/tools/filesystem.md)**                       | File and directory operations      | `FILESYSTEM_TOOL_ENABLE=true` | Read, write, edit, search files  |
 
 👉 **[See detailed tool documentation](docs/tools/overview.md)**
 

--- a/docs/creating-new-tools.md
+++ b/docs/creating-new-tools.md
@@ -14,6 +14,7 @@ The MCP DevTools server is designed to be easily extensible with new tools. This
   - [Example: Hello World Tool](#example-hello-world-tool)
     - [Testing Your Tool](#testing-your-tool)
   - [Testing](#testing)
+  - [Additional Considerations](#additional-considerations)
 
 ## Tool Interface
 
@@ -282,3 +283,13 @@ make test
 # Run only fast tests (no external dependencies)
 make test-fast
 ```
+
+## Additional Considerations
+
+- You must remember to register tools so that MCP clients can discover them.
+- Tool descriptions and parameter annotations are important for the AI agents to understand how to use the tools effectively, but must be concise and clear so they don't overload the context.
+  - If you want to create a function to help with debugging to testing a tool but don't want to expose it to MCP clients using the server, you can do so, just make sure you add a comment that it is a function not intended to be exposed to MCP clients.
+- All tools should work on both macOS and Linux unless otherwise specified (we do not need to support Windows).
+- Tools should have fast, concise unit tests that do not rely on external dependencies or services.
+- No tool should ever log to stdout or stderr when the MCP server is running in stdio mode as this breaks the MCP protocol.
+- Follow least privilege security principles.

--- a/docs/tools/find_long_files.md
+++ b/docs/tools/find_long_files.md
@@ -1,0 +1,121 @@
+# Find Long Files Tool
+
+The Find Long Files tool efficiently identifies code files that exceed a specified line count threshold, helping AI coding agents to identify files that may need refactoring for effective reading, editing and understanding.
+
+## Overview
+
+This tool scans a project directory and returns a formatted checklist of files that are longer than a specified threshold (default: 700 lines). It's designed to help maintain code quality by identifying files that may have grown too large and need to be split into smaller, more manageable components.
+
+## Features
+
+- **Fast Line Counting**: Uses optimised buffer-based counting for superior performance
+- **Comprehensive Exclusions**: Automatically excludes binary files, build artifacts, and common non-code files
+- **Gitignore Respect**: Automatically respects `.gitignore` patterns in the project
+- **Permission Handling**: Gracefully handles permission errors without failing
+- **Environment Variables**: Configurable via environment variables for automation
+- **Formatted Output**: Returns a clean checklist with line counts, file sizes, and execution timing
+
+## Usage Examples
+
+While intended to be activated via a prompt to an agent, below are some example JSON tool calls.
+
+### Basic Project Scan
+```json
+{
+  "name": "find_long_files",
+  "arguments": {
+    "path": "/Users/username/git/my-project"
+  }
+}
+```
+
+### Custom Line Threshold
+```json
+{
+  "name": "find_long_files",
+  "arguments": {
+    "path": "/Users/username/git/my-project",
+    "line_threshold": 500
+  }
+}
+```
+
+### Additional File Exclusions
+```json
+{
+  "name": "find_long_files",
+  "arguments": {
+    "path": "/Users/username/git/my-project",
+    "line_threshold": 800,
+    "additional_excludes": ["**/*.generated.js", "**/migrations/**"]
+  }
+}
+```
+
+## Parameters
+
+| Parameter             | Type   | Required | Default | Description                                                             |
+|-----------------------|--------|----------|---------|-------------------------------------------------------------------------|
+| `path`                | string | Yes      | -       | Absolute directory path to search (e.g., '/Users/username/git/project') |
+| `line_threshold`      | number | No       | 700     | Minimum number of lines to consider a file 'long'                       |
+| `additional_excludes` | array  | No       | []      | Additional glob patterns to exclude beyond .gitignore                   |
+
+## Environment Variables
+
+| Variable                              | Description                                          | Example                     |
+|---------------------------------------|------------------------------------------------------|-----------------------------|
+| `LONG_FILES_DEFAULT_LENGTH`           | Override default line threshold                      | `1000`                      |
+| `LONG_FILES_ADDITIONAL_EXCLUDES`      | Comma-separated additional exclusion patterns        | `**/*.test.js,**/*.spec.js` |
+| `LONG_FILES_RETURN_PROMPT`            | Custom message returned with the checklist (set to empty string `""` to disable) | `Custom instructions...`    |
+| `LONG_FILES_SORT_BY_DIRECTORY_TOTALS` | Sort by directory totals instead of individual files | `true`                      |
+
+## Default Exclusions
+
+The tool automatically excludes many file types and directories:
+
+### Binary and Document Files
+- Office documents: `**/*.docx`, `**/*.pdf`, `**/*.pptx`, etc.
+- Images: `**/*.png`, `**/*.jpg`, `**/*.gif`, etc.
+- Archives: `**/*.zip`, `**/*.tar`, `**/*.gz`, etc.
+- Executables: `**/*.exe`, `**/*.dll`, `**/*.bin`, etc.
+
+### Development Artifacts
+- Build directories: `**/build/**`, `**/dist/**`, `**/target/**`
+- Dependencies: `**/node_modules/**`, `**/vendor/**`
+- Caches: `**/.cache/**`, `**/__pycache__/**`
+- Version control: `**/.git/**`, `**/.svn/**`
+
+### Temporary and System Files
+- Logs: `**/*.log`, `**/*.out.*`
+- Temporary: `**/*.tmp`, `**/*.bak`, `**/*.swp`
+- System: `**/.DS_Store`, `**/Thumbs.db`
+
+## Output Format
+
+The tool returns a formatted checklist with:
+
+```markdown
+# Checklist of files over 700 lines
+
+Last checked: 2025-07-29 09:29:46
+Calculated in: 2.4s
+
+- [ ] `./backend/main.py`: 1500 Lines, 108KB
+- [ ] `./frontend/components/AgentNetwork.tsx`: 1492 Lines, 95KB
+- [ ] `./backend/agents/orchestrator_agent.py`: 1248 Lines, 87KB
+
+Next Steps (Unless the user has instructed you otherwise):
+
+1. Please take this checklist and save it to a temporary location.
+2. Perform a quick review of the identified files and under each checklist item adds a concise (1-2 sentences) summary of what should be done to reduce the file length - for example the best solution might be to split the file up into multiple files and if so what sort of pattern or logic should be used to decide what goes where ensuring your strategy values concise, clean, efficient code and operations.
+3. Then stop and ask the user to review.
+
+## Performance
+
+The tool uses optimised algorithms for fast execution:
+- Buffer-based line counting (4.5x faster than traditional scanning)
+- 32KB read buffers for optimal I/O performance
+- Efficient binary file detection
+- Permission-aware directory traversal
+
+Typical performance: 1-4s for medium-sized projects.

--- a/internal/tools/filelength/find_long_files.go
+++ b/internal/tools/filelength/find_long_files.go
@@ -1,0 +1,615 @@
+package filelength
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sammcj/mcp-devtools/internal/registry"
+	"github.com/sirupsen/logrus"
+)
+
+// FindLongFilesTool implements finding files with excessive line counts
+type FindLongFilesTool struct{}
+
+// init registers the find-long-files tool
+func init() {
+	registry.Register(&FindLongFilesTool{})
+}
+
+// Definition returns the tool's definition for MCP registration
+func (t *FindLongFilesTool) Definition() mcp.Tool {
+	// Check if return prompt is disabled
+	returnPrompt, envExists := os.LookupEnv("LONG_FILES_RETURN_PROMPT")
+	isPromptDisabled := envExists && strings.TrimSpace(returnPrompt) == ""
+
+	// Build description based on whether prompt is enabled
+	baseDescription := `Efficiently find files that have a high line count, highlighting that they may need refactoring.
+
+- Ignores binaries
+- Respects .gitignore
+- Returns a formatted checklist of files exceeding the threshold`
+
+	var description string
+	if isPromptDisabled {
+		description = baseDescription + "."
+	} else {
+		description = baseDescription + " and suggestions for the next step in handling them."
+	}
+
+	return mcp.NewTool(
+		"find_long_files",
+		mcp.WithDescription(description),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Absolute directory path to search for long files (e.g. '/Users/username/git/project')"),
+		),
+		mcp.WithNumber("line_threshold",
+			mcp.Description("Minimum number of lines to consider 'long' (default: 700)"),
+			mcp.DefaultNumber(700),
+		),
+		mcp.WithArray("additional_excludes",
+			mcp.Description("Additional glob patterns to exclude"),
+		),
+	)
+}
+
+// Execute executes the find-long-files tool
+func (t *FindLongFilesTool) Execute(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	startTime := time.Now()
+	logger.Info("Executing find-long-files tool")
+
+	// Parse and validate parameters
+	request, err := t.parseRequest(args)
+	if err != nil {
+		return nil, fmt.Errorf("invalid parameters: %w", err)
+	}
+
+	logger.WithFields(logrus.Fields{
+		"path":                     request.Path,
+		"line_threshold":           request.LineThreshold,
+		"additional_excludes":      request.AdditionalExcludes,
+		"sort_by_directory_totals": request.SortByDirectoryTotals,
+	}).Debug("Find long files parameters")
+
+	// Find long files
+	longFiles, totalScanned, err := t.findLongFiles(ctx, logger, request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find long files: %w", err)
+	}
+
+	// Generate checklist
+	checklist := t.generateChecklist(longFiles, request, startTime)
+
+	// Get default message from environment or use default
+	defaultMessage, envExists := os.LookupEnv("LONG_FILES_RETURN_PROMPT")
+	if !envExists {
+		// Environment variable not set, use default
+		defaultMessage = `**Suggested Next Steps (Unless the user has instructed you otherwise)**:
+1. Take this checklist and save it to a temporary location.
+2. Perform a _quick_ review of the identified files and under each checklist item adds a concise (1-2 sentences) summary of what should be done to reduce the file length, considering what sort of pattern or logic should be used to decide how the code or content should be split (or if not - why), ensuring your strategy values concise, clean, efficient code and operations.
+3. Then stop and ask the user to review.`
+	} else {
+		// Environment variable is set - if it's empty/whitespace, user wants no message
+		defaultMessage = strings.TrimSpace(defaultMessage)
+	}
+
+	response := &FindLongFilesResponse{
+		Checklist:         checklist,
+		LastChecked:       startTime,
+		CalculationTime:   time.Since(startTime).String(),
+		TotalFilesScanned: totalScanned,
+		TotalFilesFound:   len(longFiles),
+		Message:           defaultMessage,
+	}
+
+	logger.WithFields(logrus.Fields{
+		"total_files_scanned": totalScanned,
+		"total_files_found":   len(longFiles),
+		"calculation_time":    response.CalculationTime,
+	}).Info("Find long files completed successfully")
+
+	// Only include message if it's not empty after trimming
+	if defaultMessage == "" {
+		return t.newToolResultText(response.Checklist)
+	}
+	return t.newToolResultText(fmt.Sprintf("%s\n\n%s", response.Checklist, response.Message))
+}
+
+// parseRequest parses and validates the tool arguments
+func (t *FindLongFilesTool) parseRequest(args map[string]interface{}) (*FindLongFilesRequest, error) {
+	request := &FindLongFilesRequest{
+		LineThreshold:         700,
+		AdditionalExcludes:    []string{},
+		SortByDirectoryTotals: false,
+	}
+
+	// Parse path (required)
+	pathRaw, ok := args["path"].(string)
+	if !ok || pathRaw == "" {
+		return nil, fmt.Errorf("missing required parameter: path")
+	}
+
+	// Validate that path is absolute
+	if !filepath.IsAbs(pathRaw) {
+		return nil, fmt.Errorf("path must be absolute (e.g., '/Users/username/project'), got: %s", pathRaw)
+	}
+
+	request.Path = pathRaw
+
+	// Parse line threshold - check environment variable first
+	if envThreshold := os.Getenv("LONG_FILES_DEFAULT_LENGTH"); envThreshold != "" {
+		if threshold, err := strconv.Atoi(envThreshold); err == nil && threshold > 0 {
+			request.LineThreshold = threshold
+		}
+	}
+	if thresholdRaw, ok := args["line_threshold"].(float64); ok {
+		threshold := int(thresholdRaw)
+		if threshold < 1 {
+			return nil, fmt.Errorf("line_threshold must be at least 1")
+		}
+		request.LineThreshold = threshold
+	}
+
+	// Parse additional excludes - check environment variable first
+	if envExcludes := os.Getenv("LONG_FILES_ADDITIONAL_EXCLUDES"); envExcludes != "" {
+		request.AdditionalExcludes = strings.Split(envExcludes, ",")
+		for i, exclude := range request.AdditionalExcludes {
+			request.AdditionalExcludes[i] = strings.TrimSpace(exclude)
+		}
+	}
+	if excludesRaw, ok := args["additional_excludes"].([]interface{}); ok {
+		excludes := make([]string, len(excludesRaw))
+		for i, exclude := range excludesRaw {
+			if excludeStr, ok := exclude.(string); ok {
+				excludes[i] = excludeStr
+			}
+		}
+		request.AdditionalExcludes = excludes
+	}
+
+	// Parse sort option from environment variable
+	if envSort := os.Getenv("LONG_FILES_SORT_BY_DIRECTORY_TOTALS"); envSort != "" {
+		if envSort == "true" || envSort == "1" {
+			request.SortByDirectoryTotals = true
+		}
+	}
+
+	// Validate path exists
+	if _, err := os.Stat(request.Path); os.IsNotExist(err) {
+		return nil, fmt.Errorf("path does not exist: %s", request.Path)
+	}
+
+	return request, nil
+}
+
+// findLongFiles finds all files exceeding the line threshold
+func (t *FindLongFilesTool) findLongFiles(ctx context.Context, logger *logrus.Logger, request *FindLongFilesRequest) ([]FileInfo, int, error) {
+	var longFiles []FileInfo
+	totalScanned := 0
+
+	// Load gitignore patterns
+	gitignorePatterns, err := t.loadGitignorePatterns(request.Path)
+	if err != nil {
+		logger.WithError(err).Warn("Failed to load .gitignore patterns, continuing without them")
+	}
+
+	// Walk the directory tree
+	err = filepath.Walk(request.Path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Handle permission errors gracefully - skip inaccessible files/directories
+			if os.IsPermission(err) {
+				logger.WithError(err).WithField("path", path).Debug("Skipping path due to permission error")
+				if info != nil && info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			// Check if we have read permission on the directory
+			if !t.hasReadPermission(path) {
+				logger.WithField("dir", path).Debug("Skipping directory due to lack of read permission")
+				return filepath.SkipDir
+			}
+			return nil
+		}
+
+		// Check if file should be excluded
+		if t.shouldExcludeFile(path, gitignorePatterns, request.AdditionalExcludes) {
+			return nil
+		}
+
+		// Check if we have read permission on the file
+		if !t.hasReadPermission(path) {
+			logger.WithField("file", path).Debug("Skipping file due to lack of read permission")
+			return nil
+		}
+
+		// Skip binary files
+		if t.isBinaryFile(path) {
+			return nil
+		}
+
+		totalScanned++
+
+		// Count lines in file
+		lineCount, err := t.countLines(path)
+		if err != nil {
+			logger.WithError(err).WithField("file", path).Warn("Failed to count lines in file")
+			return nil
+		}
+
+		// Check if file exceeds threshold
+		if lineCount >= request.LineThreshold {
+			relPath, _ := filepath.Rel(request.Path, path)
+			if !strings.HasPrefix(relPath, "./") && !strings.HasPrefix(relPath, "../") {
+				relPath = "./" + relPath
+			}
+
+			longFiles = append(longFiles, FileInfo{
+				Path:      relPath,
+				LineCount: lineCount,
+				Directory: filepath.Dir(relPath),
+				SizeBytes: info.Size(),
+			})
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, totalScanned, err
+	}
+
+	// Sort files
+	if request.SortByDirectoryTotals {
+		longFiles = t.sortByDirectoryTotals(longFiles)
+	} else {
+		// Sort by line count descending
+		sort.Slice(longFiles, func(i, j int) bool {
+			return longFiles[i].LineCount > longFiles[j].LineCount
+		})
+	}
+
+	return longFiles, totalScanned, nil
+}
+
+// loadGitignorePatterns loads gitignore patterns from .gitignore file
+func (t *FindLongFilesTool) loadGitignorePatterns(basePath string) ([]string, error) {
+	gitignorePath := filepath.Join(basePath, ".gitignore")
+	file, err := os.Open(gitignorePath)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	var patterns []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" && !strings.HasPrefix(line, "#") {
+			patterns = append(patterns, line)
+		}
+	}
+
+	return patterns, scanner.Err()
+}
+
+// getDefaultExcludePatterns returns comprehensive default exclusion patterns
+func (t *FindLongFilesTool) getDefaultExcludePatterns() []string {
+	return []string{
+		// Binary document formats
+		"**/*.docx", "**/*.doc", "**/*.rtf", "**/*.odt",
+		"**/*.pptx", "**/*.ppt", "**/*.odp",
+		"**/*.xlsx", "**/*.xls", "**/*.ods",
+		"**/*.pdf",
+
+		// Image formats
+		"**/*.png", "**/*.jpg", "**/*.jpeg", "**/*.gif", "**/*.bmp",
+		"**/*.tiff", "**/*.tif", "**/*.webp", "**/*.ico", "**/*.svg",
+
+		// Audio/Video formats
+		"**/*.mp3", "**/*.mp4", "**/*.avi", "**/*.mov", "**/*.wmv",
+		"**/*.flv", "**/*.webm", "**/*.ogg", "**/*.wav", "**/*.flac",
+
+		// Archive formats
+		"**/*.zip", "**/*.tar", "**/*.gz", "**/*.bz2", "**/*.xz",
+		"**/*.7z", "**/*.rar", "**/*.dmg", "**/*.iso",
+
+		// Binary/executable formats
+		"**/*.bin", "**/*.exe", "**/*.dll", "**/*.so", "**/*.dylib",
+		"**/*.class", "**/*.jar", "**/*.war", "**/*.ear",
+		"**/*.deb", "**/*.rpm", "**/*.pkg", "**/*.msi",
+
+		// Certificate and key files
+		"**/*.pem", "**/*.crt", "**/*.cer", "**/*.p12", "**/*.pfx",
+		"**/*.key", "**/*.pub", "**/*.gpg",
+
+		// Temporary and log files
+		"**/*.tmp", "**/*.temp", "**/*.bak", "**/*.swp", "**/*.swo",
+		"**/*.log", "**/*.log.*", "**/*.out", "**/*.out.*",
+		"**/*.old", "**/*.orig", "**/*.rej",
+
+		// Common directories to exclude
+		"**/node_modules/**", "**/.git/**", "**/.svn/**", "**/.hg/**",
+		"**/.bzr/**", "**/vendor/**", "**/.venv/**", "**/venv/**",
+		"**/__pycache__/**", "**/.pytest_cache/**", "**/coverage/**",
+		"**/build/**", "**/dist/**", "**/target/**", "**/bin/**",
+		"**/.npm/**", "**/.yarn/**", "**/.cache/**", "**/cache/**",
+		"**/.DS_Store", "**/Thumbs.db",
+
+		// Common license and documentation files (exact matches)
+		"LICENSE", "LICENCE", "LICENSE.*", "LICENCE.*",
+		"CONTRIBUTING", "CONTRIBUTING.*", "CHANGELOG", "CHANGELOG.*",
+		"AUTHORS", "AUTHORS.*", "CREDITS", "CREDITS.*",
+		"COPYING", "COPYING.*", "NOTICE", "NOTICE.*",
+
+		// Font files
+		"**/*.ttf", "**/*.otf", "**/*.woff", "**/*.woff2", "**/*.eot",
+
+		// Database files
+		"**/*.db", "**/*.sqlite", "**/*.sqlite3", "**/*.mdb",
+
+		// IDE and editor files
+		"**/.vscode/**", "**/.idea/**", "**/*.sublime-*",
+		"**/.settings/**", "**/.project", "**/.classpath",
+	}
+}
+
+// shouldExcludeFile checks if a file should be excluded based on patterns
+func (t *FindLongFilesTool) shouldExcludeFile(path string, gitignorePatterns, additionalExcludes []string) bool {
+	// Get relative path for pattern matching
+	fileName := filepath.Base(path)
+
+	// First check default exclusions (most efficient, checks binary files first)
+	defaultExcludes := t.getDefaultExcludePatterns()
+	for _, pattern := range defaultExcludes {
+		if t.matchesPattern(path, fileName, pattern) {
+			return true
+		}
+	}
+
+	// Check gitignore patterns
+	for _, pattern := range gitignorePatterns {
+		if t.matchesPattern(path, fileName, pattern) {
+			return true
+		}
+	}
+
+	// Check additional excludes from user/environment
+	for _, pattern := range additionalExcludes {
+		if t.matchesPattern(path, fileName, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// matchesPattern checks if a file path matches a given pattern
+func (t *FindLongFilesTool) matchesPattern(path, fileName, pattern string) bool {
+	// Handle exact filename matches (like LICENSE)
+	if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "/") {
+		return fileName == pattern || strings.HasPrefix(fileName, pattern+".")
+	}
+
+	// Handle directory patterns like "**/.git/**"
+	if strings.HasSuffix(pattern, "/**") {
+		dirPattern := strings.TrimSuffix(pattern, "/**")
+		// Remove leading **/ if present
+		dirPattern = strings.TrimPrefix(dirPattern, "**/")
+		// Check if path contains this directory
+		return strings.Contains(path, "/"+dirPattern+"/") ||
+			strings.HasPrefix(path, dirPattern+"/") ||
+			strings.HasPrefix(path, "./"+dirPattern+"/")
+	}
+
+	// Handle patterns starting with **/ (like "**/*.bin")
+	if strings.HasPrefix(pattern, "**/") {
+		simplePattern := strings.TrimPrefix(pattern, "**/")
+		// Try to match against filename
+		if matched, _ := filepath.Match(simplePattern, fileName); matched {
+			return true
+		}
+		// Try to match against the entire path
+		if matched, _ := filepath.Match(simplePattern, path); matched {
+			return true
+		}
+	}
+
+	// Handle regular glob patterns
+	if matched, _ := filepath.Match(pattern, fileName); matched {
+		return true
+	}
+	if matched, _ := filepath.Match(pattern, path); matched {
+		return true
+	}
+
+	// Handle simple substring matches for patterns without globs
+	if !strings.Contains(pattern, "*") {
+		return strings.Contains(path, pattern)
+	}
+
+	return false
+}
+
+// isBinaryFile checks if a file is binary by reading a small sample
+func (t *FindLongFilesTool) isBinaryFile(path string) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return true // Assume binary if we can't read it
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	// Read first 512 bytes to check for binary content
+	buffer := make([]byte, 512)
+	n, err := file.Read(buffer)
+	if err != nil && err != io.EOF {
+		return true
+	}
+
+	// Check for null bytes (common in binary files)
+	for i := 0; i < n; i++ {
+		if buffer[i] == 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// countLines efficiently counts lines in a file using bytes.Count for optimal performance
+func (t *FindLongFilesTool) countLines(path string) (int, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+
+	// Use optimised buffer-based counting for better performance
+	// Based on JimBLineCounter from go-line-counter benchmark results
+	const bufferSize = 32 * 1024 // 32KB buffer provides optimal performance
+	buf := make([]byte, bufferSize)
+	lineCount := 0
+	lineSep := []byte("\n")
+
+	for {
+		n, err := file.Read(buf)
+		if n > 0 {
+			lineCount += bytes.Count(buf[:n], lineSep)
+		}
+		if err != nil {
+			if err == io.EOF {
+				return lineCount, nil
+			}
+			return lineCount, err
+		}
+	}
+}
+
+// sortByDirectoryTotals sorts files by directory totals
+func (t *FindLongFilesTool) sortByDirectoryTotals(files []FileInfo) []FileInfo {
+	// Group files by directory
+	dirMap := make(map[string]*DirectoryInfo)
+	for _, file := range files {
+		if dirInfo, exists := dirMap[file.Directory]; exists {
+			dirInfo.Files = append(dirInfo.Files, file)
+			dirInfo.TotalLines += file.LineCount
+			dirInfo.FileCount++
+		} else {
+			dirMap[file.Directory] = &DirectoryInfo{
+				Path:       file.Directory,
+				Files:      []FileInfo{file},
+				TotalLines: file.LineCount,
+				FileCount:  1,
+			}
+		}
+	}
+
+	// Convert to slice and sort by total lines, then by file count
+	var dirs []*DirectoryInfo
+	for _, dirInfo := range dirMap {
+		dirs = append(dirs, dirInfo)
+	}
+
+	sort.Slice(dirs, func(i, j int) bool {
+		if dirs[i].TotalLines == dirs[j].TotalLines {
+			return dirs[i].FileCount > dirs[j].FileCount
+		}
+		return dirs[i].TotalLines > dirs[j].TotalLines
+	})
+
+	// Flatten back to file list
+	var result []FileInfo
+	for _, dirInfo := range dirs {
+		// Sort files within directory by line count
+		sort.Slice(dirInfo.Files, func(i, j int) bool {
+			return dirInfo.Files[i].LineCount > dirInfo.Files[j].LineCount
+		})
+		result = append(result, dirInfo.Files...)
+	}
+
+	return result
+}
+
+// generateChecklist generates the formatted checklist output
+func (t *FindLongFilesTool) generateChecklist(files []FileInfo, request *FindLongFilesRequest, startTime time.Time) string {
+	var builder strings.Builder
+
+	// Format calculation time in seconds with one decimal place
+	calculationTime := time.Since(startTime).Seconds()
+	timeFormatted := fmt.Sprintf("%.1fs", calculationTime)
+
+	builder.WriteString(fmt.Sprintf("# Checklist of files over %d lines\n\n", request.LineThreshold))
+	builder.WriteString(fmt.Sprintf("Last checked: %s\n", startTime.Format("2006-01-02 15:04:05")))
+	builder.WriteString(fmt.Sprintf("Calculated in: %s\n\n", timeFormatted))
+
+	if len(files) == 0 {
+		builder.WriteString("No files found exceeding the line threshold.\n")
+		return builder.String()
+	}
+
+	for _, file := range files {
+		sizeFormatted := t.formatFileSize(file.SizeBytes)
+		builder.WriteString(fmt.Sprintf("- [ ] `%s`: %d Lines, %s\n", file.Path, file.LineCount, sizeFormatted))
+	}
+
+	return builder.String()
+}
+
+// hasReadPermission checks if we have read permission on a file or directory
+func (t *FindLongFilesTool) hasReadPermission(path string) bool {
+	file, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	return true
+}
+
+// formatFileSize formats file size in human-readable format
+func (t *FindLongFilesTool) formatFileSize(sizeBytes int64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+	)
+
+	switch {
+	case sizeBytes >= GB:
+		return fmt.Sprintf("%.1fGB", float64(sizeBytes)/GB)
+	case sizeBytes >= MB:
+		return fmt.Sprintf("%.1fMB", float64(sizeBytes)/MB)
+	case sizeBytes >= KB:
+		return fmt.Sprintf("%.0fKB", float64(sizeBytes)/KB)
+	default:
+		return fmt.Sprintf("%dB", sizeBytes)
+	}
+}
+
+// newToolResultText creates a new tool result with text content
+func (t *FindLongFilesTool) newToolResultText(content string) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultText(content), nil
+}

--- a/internal/tools/filelength/types.go
+++ b/internal/tools/filelength/types.go
@@ -1,0 +1,37 @@
+package filelength
+
+import "time"
+
+// FindLongFilesRequest represents the request to find long files
+type FindLongFilesRequest struct {
+	Path                  string   `json:"path"`
+	LineThreshold         int      `json:"line_threshold"`
+	AdditionalExcludes    []string `json:"additional_excludes"`
+	SortByDirectoryTotals bool     `json:"sort_by_directory_totals"`
+}
+
+// FindLongFilesResponse represents the response with long files found
+type FindLongFilesResponse struct {
+	Checklist         string    `json:"checklist"`
+	LastChecked       time.Time `json:"last_checked"`
+	CalculationTime   string    `json:"calculation_time"`
+	TotalFilesScanned int       `json:"total_files_scanned"`
+	TotalFilesFound   int       `json:"total_files_found"`
+	Message           string    `json:"message"`
+}
+
+// FileInfo represents information about a file that exceeds the line threshold
+type FileInfo struct {
+	Path      string `json:"path"`
+	LineCount int    `json:"line_count"`
+	Directory string `json:"directory"`
+	SizeBytes int64  `json:"size_bytes"`
+}
+
+// DirectoryInfo represents aggregated information about a directory
+type DirectoryInfo struct {
+	Path       string     `json:"path"`
+	Files      []FileInfo `json:"files"`
+	TotalLines int        `json:"total_lines"`
+	FileCount  int        `json:"file_count"`
+}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ import (
 
 	// Import all tool packages to register them
 	_ "github.com/sammcj/mcp-devtools/internal/tools/docprocessing"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/filelength"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/filesystem"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/github"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/internetsearch/unified"

--- a/tests/tools/find_long_files_test.go
+++ b/tests/tools/find_long_files_test.go
@@ -1,0 +1,285 @@
+package tools
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sammcj/mcp-devtools/internal/tools/filelength"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindLongFilesTool(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "find_long_files_test")
+	require.NoError(t, err)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
+
+	// Create test files
+	testFiles := map[string]int{
+		"short.go":       50,   // Should not be included
+		"medium.js":      500,  // Should not be included
+		"long.py":        800,  // Should be included
+		"very_long.java": 1200, // Should be included
+		"binary.bin":     100,  // Should be skipped (binary)
+	}
+
+	for filename, lineCount := range testFiles {
+		content := strings.Repeat("// This is a test line\n", lineCount)
+
+		// Make binary file actually binary
+		if strings.HasSuffix(filename, ".bin") {
+			content = string([]byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05})
+		}
+
+		err := os.WriteFile(filepath.Join(tempDir, filename), []byte(content), 0644)
+		require.NoError(t, err)
+	}
+
+	// Create .gitignore file
+	gitignoreContent := "*.tmp\n*.log\n"
+	err = os.WriteFile(filepath.Join(tempDir, ".gitignore"), []byte(gitignoreContent), 0644)
+	require.NoError(t, err)
+
+	// Create a .tmp file that should be ignored
+	err = os.WriteFile(filepath.Join(tempDir, "ignored.tmp"), []byte(strings.Repeat("line\n", 900)), 0644)
+	require.NoError(t, err)
+
+	// Initialize the tool
+	tool := &filelength.FindLongFilesTool{}
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel) // Reduce noise in tests
+	cache := &sync.Map{}
+
+	tests := []struct {
+		name     string
+		args     map[string]interface{}
+		expected []string // Expected file paths in results
+	}{
+		{
+			name: "default threshold 700",
+			args: map[string]interface{}{
+				"path": tempDir,
+			},
+			expected: []string{"./long.py", "./very_long.java"},
+		},
+		{
+			name: "custom threshold 500",
+			args: map[string]interface{}{
+				"path":           tempDir,
+				"line_threshold": float64(500),
+			},
+			expected: []string{"./medium.js", "./long.py", "./very_long.java"},
+		},
+		{
+			name: "high threshold",
+			args: map[string]interface{}{
+				"path":           tempDir,
+				"line_threshold": float64(1500),
+			},
+			expected: []string{}, // No files should meet this threshold
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tool.Execute(context.Background(), logger, cache, tt.args)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			// Get the content
+			require.True(t, len(result.Content) > 0, "Expected content in result")
+			textContent, ok := mcp.AsTextContent(result.Content[0])
+			require.True(t, ok, "Expected TextContent type")
+			content := textContent.Text
+			assert.Contains(t, content, "# Checklist of files over")
+
+			// Check that expected files are present
+			for _, expectedFile := range tt.expected {
+				assert.Contains(t, content, expectedFile, "Expected file %s should be in results", expectedFile)
+			}
+
+			// Check that ignored files are not present
+			assert.NotContains(t, content, "ignored.tmp", "Ignored files should not be in results")
+			assert.NotContains(t, content, "binary.bin", "Binary files should not be in results")
+
+			// If no files expected, check the message
+			if len(tt.expected) == 0 {
+				assert.Contains(t, content, "No files found exceeding the line threshold")
+			}
+		})
+	}
+}
+
+func TestFindLongFilesTool_ParseRequest(t *testing.T) {
+	tool := &filelength.FindLongFilesTool{}
+
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "parse_request_test")
+	require.NoError(t, err)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
+
+	tests := []struct {
+		name           string
+		args           map[string]interface{}
+		expectError    bool
+		checkPath      string
+		checkThreshold int
+	}{
+		{
+			name:        "missing path parameter",
+			args:        map[string]interface{}{},
+			expectError: true,
+		},
+		{
+			name: "valid absolute path",
+			args: map[string]interface{}{
+				"path":           tempDir,
+				"line_threshold": float64(1000),
+			},
+			expectError: false,
+		},
+		{
+			name: "invalid threshold",
+			args: map[string]interface{}{
+				"path":           tempDir,
+				"line_threshold": float64(0),
+			},
+			expectError: true,
+		},
+		{
+			name: "nonexistent path",
+			args: map[string]interface{}{
+				"path": "/nonexistent/path/that/does/not/exist",
+			},
+			expectError: true,
+		},
+		{
+			name: "relative path",
+			args: map[string]interface{}{
+				"path": "./relative/path",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Use reflection to access the private parseRequest method
+			// In a real scenario, you might make this method public for testing
+			// or test it indirectly through Execute
+			logger := logrus.New()
+			logger.SetLevel(logrus.ErrorLevel)
+			cache := &sync.Map{}
+
+			_, err := tool.Execute(context.Background(), logger, cache, tt.args)
+
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				// For valid cases, we expect success
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestFindLongFilesTool_EnvironmentVariables(t *testing.T) {
+	// Save original environment
+	originalThreshold := os.Getenv("LONG_FILES_DEFAULT_LENGTH")
+	originalExcludes := os.Getenv("LONG_FILES_ADDITIONAL_EXCLUDES")
+	originalPrompt := os.Getenv("LONG_FILES_RETURN_PROMPT")
+
+	defer func() {
+		// Restore original environment
+		if originalThreshold == "" {
+			_ = os.Unsetenv("LONG_FILES_DEFAULT_LENGTH")
+		} else {
+			_ = os.Setenv("LONG_FILES_DEFAULT_LENGTH", originalThreshold)
+		}
+		if originalExcludes == "" {
+			_ = os.Unsetenv("LONG_FILES_ADDITIONAL_EXCLUDES")
+		} else {
+			_ = os.Setenv("LONG_FILES_ADDITIONAL_EXCLUDES", originalExcludes)
+		}
+		if originalPrompt == "" {
+			_ = os.Unsetenv("LONG_FILES_RETURN_PROMPT")
+		} else {
+			_ = os.Setenv("LONG_FILES_RETURN_PROMPT", originalPrompt)
+		}
+	}()
+
+	// Test environment variable for threshold
+	require.NoError(t, os.Setenv("LONG_FILES_DEFAULT_LENGTH", "500"))
+	require.NoError(t, os.Setenv("LONG_FILES_ADDITIONAL_EXCLUDES", "*.test,*.spec"))
+	require.NoError(t, os.Setenv("LONG_FILES_RETURN_PROMPT", "Custom test message"))
+
+	// Create a temporary directory for testing
+	tempDir, err := os.MkdirTemp("", "env_test")
+	require.NoError(t, err)
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Logf("Failed to remove temp dir: %v", err)
+		}
+	}()
+
+	// Create a test file that should be found with threshold 500
+	content := strings.Repeat("// Test line\n", 600)
+	err = os.WriteFile(filepath.Join(tempDir, "test.go"), []byte(content), 0644)
+	require.NoError(t, err)
+
+	tool := &filelength.FindLongFilesTool{}
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	cache := &sync.Map{}
+
+	args := map[string]interface{}{
+		"path": tempDir,
+		// Don't set line_threshold to test environment variable
+	}
+
+	result, err := tool.Execute(context.Background(), logger, cache, args)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	require.True(t, len(result.Content) > 0, "Expected content in result")
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	require.True(t, ok, "Expected TextContent type")
+	content_result := textContent.Text
+
+	// Should find the file because env var sets threshold to 500
+	assert.Contains(t, content_result, "test.go")
+
+	// Should contain custom message
+	assert.Contains(t, content_result, "Custom test message")
+}
+
+func TestFindLongFilesTool_Definition(t *testing.T) {
+	tool := &filelength.FindLongFilesTool{}
+	definition := tool.Definition()
+
+	assert.Equal(t, "find_long_files", definition.Name)
+	assert.NotEmpty(t, definition.Description)
+
+	// Check that required parameters are defined
+	inputSchema := definition.InputSchema
+	assert.NotNil(t, inputSchema)
+
+	// Just check that the schema exists and has properties
+	// The exact structure checking is less important than functionality
+	assert.NotNil(t, inputSchema.Properties, "InputSchema should have properties")
+}


### PR DESCRIPTION
- Feature: New Tool - Find Long Files

## Find Long Files Tool

The Find Long Files tool efficiently identifies code files that exceed a specified line count threshold, helping AI coding agents to identify files that may need refactoring for effective reading, editing and understanding.

This tool scans a project directory and returns a formatted checklist of files that are longer than a specified threshold (default: 700 lines). It's designed to help maintain code quality by identifying files that may have grown too large and need to be split into smaller, more manageable components.