### PR TITLE
fix: disable sbom and vuln scanning tool in normal builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ echo "${GOPATH}/bin/mcp-devtools" # Use this path in your MCP configuration, if 
 xattr -r -d com.apple.quarantine ${GOPATH}/bin/mcp-devtools
 ```
 
-2. Update your MCP client to add the MCP DevTools server configuration, replacing `/path/to/mcp-devtools` with the actual path to the binary (e.g. `/Users/samm/go/bin/mcp-devtools`):
+1. Update your MCP client to add the MCP DevTools server configuration, replacing `/path/to/mcp-devtools` with the actual path to the binary (e.g. `/Users/samm/go/bin/mcp-devtools`):
 ```json
 {
   "mcpServers": {
@@ -147,7 +147,7 @@ cd mcp-devtools
 make build
 ```
 
-**Option 3: Download Release**
+**Option 4: Download Release**
 Download the latest binary from [releases](https://github.com/sammcj/mcp-devtools/releases) and place in your PATH and remember to check for updates!
 
 ### Basic MCP Configuration
@@ -332,6 +332,19 @@ Configuration is managed through `~/.mcp-devtools/security.yaml` with sensible d
 👉 **[Complete Security Documentation](docs/security.md)**
 
 ## Advanced Features
+
+### SBOM/Vulnerability Tools Build (Increases File Size)
+Includes all tools including SBOM generation and vulnerability scanning capabilities with Anchore Syft/Grype dependencies (~170MB binary).
+
+```bash
+# Build with SBOM and vulnerability tools
+make build-sbom-vuln-tools
+```
+
+**Additional tools**: `sbom`, `vulnerability_scan`
+
+The SBOM and vulnerability scanning tools are disabled by default in both builds but can be enabled via the `ENABLE_ADDITIONAL_TOOLS` environment variable. In the standard build, these tools will return appropriate error messages indicating they require the SBOM/vulnerability tools build variant.
+
 
 ### OAuth 2.0/2.1 Authentication
 For production deployments requiring centralised user authentication:

--- a/docs/creating-new-tools.md
+++ b/docs/creating-new-tools.md
@@ -372,13 +372,18 @@ if result, err := security.AnalyseContent(content, source); err == nil {
 - **Override capability**: Blocked content includes security IDs for potential overrides
 - **Audit logging**: All security events are logged for review
 
-### 7. Import the Tool Package
+### 7. Register the Tool for Import
 
-Finally, import your tool package in `main.go` to ensure it's registered:
+Add your tool package to the imports registry so it gets automatically loaded. Add the import to `internal/imports/tools.go`:
 
 ```go
-import _ "github.com/sammcj/mcp-devtools/internal/tools/your-category/your-tool"
+import (
+    // ... existing imports ...
+    _ "github.com/sammcj/mcp-devtools/internal/tools/your-category/your-tool"
+)
 ```
+
+**Important**: Do NOT add your tool import directly to `main.go`. Use the imports registry system instead to ensure proper build tag handling and maintainability.
 
 ## Example: Hello World Tool
 

--- a/docs/tools/sbom.md
+++ b/docs/tools/sbom.md
@@ -19,6 +19,17 @@ Critical for modern software development, this tool creates detailed inventories
 
 ## Prerequisites
 
+This tool requires the SBOM/vulnerability tools build variant that includes heavy Anchore dependencies. If using the standard build, you'll get an error message.
+
+### Build Requirements
+- **SBOM/Vulnerability Tools Build**: Tool is fully functional with Anchore Syft integration
+
+Build with SBOM and vulnerability tools:
+```bash
+make build-sbom-vuln-tools
+```
+
+### Runtime Requirements
 This tool is disabled by default. Enable it by including `sbom` in the `ENABLE_ADDITIONAL_TOOLS` environment variable.
 
 ## Tool Usage Examples

--- a/docs/tools/vulnerability-scan.md
+++ b/docs/tools/vulnerability-scan.md
@@ -19,6 +19,16 @@ Essential for security analysis during development, this tool scans project depe
 
 ## Prerequisites
 
+This tool requires the SBOM/vulnerability tools build variant that includes heavy Anchore dependencies. If using the standard build, you'll get an error message.
+
+### Build Requirements
+
+Build with SBOM and vulnerability tools:
+```bash
+make build-sbom-vuln-tools
+```
+
+### Runtime Requirements
 This tool is disabled by default. Enable it by including `vulnerability_scan` in the `ENABLE_ADDITIONAL_TOOLS` environment variable.
 
 ## Tool Usage Examples
@@ -114,11 +124,11 @@ While intended to be activated via a prompt to an agent, below are some example 
 
 ### Output Format Options
 
-| Format         | Description                        | Best For                    |
-|----------------|------------------------------------|-----------------------------|
-| `json`         | Comprehensive vulnerability data   | Programmatic analysis       |
-| `table`        | Human-readable tabular format      | Quick manual review         |
-| `sarif`        | Static Analysis Results format     | IDE integration, toolchains |
+| Format           | Description                       | Best For                       |
+|------------------|-----------------------------------|--------------------------------|
+| `json`           | Comprehensive vulnerability data  | Programmatic analysis          |
+| `table`          | Human-readable tabular format     | Quick manual review            |
+| `sarif`          | Static Analysis Results format    | IDE integration, toolchains    |
 | `cyclonedx-json` | CycloneDX vulnerability extension | Security toolchain integration |
 
 ## Response Format

--- a/internal/imports/tools.go
+++ b/internal/imports/tools.go
@@ -1,0 +1,28 @@
+package imports
+
+import (
+	// Standard tools - always available
+	_ "github.com/sammcj/mcp-devtools/internal/tools/aws_documentation"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/claudeagent"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/docprocessing"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/filelength"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/filesystem"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/geminiagent"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/generatechangelog"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/github"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/internetsearch/unified"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/m2e"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/memory"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/packagedocs"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/packageversions/unified"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/pdf"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/securityoverride"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/shadcnui"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/think"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/utilities/toolhelp"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/webfetch"
+
+	// Security tools with conditional imports based on build tags
+	_ "github.com/sammcj/mcp-devtools/internal/tools/sbom"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/vulnerabilityscan"
+)

--- a/internal/tools/sbom/sbom.go
+++ b/internal/tools/sbom/sbom.go
@@ -1,3 +1,6 @@
+//go:build sbom_vuln_tools
+// +build sbom_vuln_tools
+
 package sbom
 
 import (

--- a/internal/tools/sbom/sbom_stub.go
+++ b/internal/tools/sbom/sbom_stub.go
@@ -1,0 +1,7 @@
+//go:build !sbom_vuln_tools
+// +build !sbom_vuln_tools
+
+package sbom
+
+// This file provides empty implementation when sbom_vuln_tools build tag is not included
+// to reduce binary size by excluding heavy Anchore dependencies

--- a/internal/tools/vulnerabilityscan/vulnerability_scan.go
+++ b/internal/tools/vulnerabilityscan/vulnerability_scan.go
@@ -1,3 +1,6 @@
+//go:build sbom_vuln_tools
+// +build sbom_vuln_tools
+
 package vulnerabilityscan
 
 import (

--- a/internal/tools/vulnerabilityscan/vulnerability_scan_stub.go
+++ b/internal/tools/vulnerabilityscan/vulnerability_scan_stub.go
@@ -1,0 +1,7 @@
+//go:build !sbom_vuln_tools
+// +build !sbom_vuln_tools
+
+package vulnerabilityscan
+
+// This file provides empty implementation when sbom_vuln_tools build tag is not included
+// to reduce binary size by excluding heavy Anchore dependencies

--- a/main.go
+++ b/main.go
@@ -21,27 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	// Import all tool packages to register them
-	_ "github.com/sammcj/mcp-devtools/internal/tools/aws_documentation"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/claudeagent"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/docprocessing"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/filelength"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/filesystem"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/geminiagent"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/generatechangelog"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/github"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/internetsearch/unified"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/m2e"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/memory"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/packagedocs"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/packageversions/unified"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/pdf"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/sbom"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/securityoverride"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/shadcnui"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/think"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/utilities/toolhelp"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/vulnerabilityscan"
-	_ "github.com/sammcj/mcp-devtools/internal/tools/webfetch"
+	_ "github.com/sammcj/mcp-devtools/internal/imports"
 )
 
 // Version information (set during build)

--- a/tests/tools/sbom_test.go
+++ b/tests/tools/sbom_test.go
@@ -1,3 +1,6 @@
+//go:build sbom_vuln_tools
+// +build sbom_vuln_tools
+
 package tools_test
 
 import (

--- a/tests/tools/vulnerability_scan_test.go
+++ b/tests/tools/vulnerability_scan_test.go
@@ -1,3 +1,6 @@
+//go:build sbom_vuln_tools
+// +build sbom_vuln_tools
+
 package tools_test
 
 import (


### PR DESCRIPTION
This pull request introduces a new build system for optional SBOM (Software Bill of Materials) and vulnerability scanning tools, making their inclusion in the binary conditional via a `sbom_vuln_tools` build tag. This reduces the default binary size and allows users to opt-in to heavy dependencies only when needed. The documentation and developer workflow are updated to reflect these changes, and imports are refactored for maintainability.

- **BREAKING**: SBOM and Vuln scanning tools will not be included in default builds (due to how much they increase the file size), see the docs if you want to build with them.

**Build system and dependency management:**

* Adds a new Makefile target (`build-sbom-vuln-tools`) to build the server with SBOM and vulnerability scanning tools, using a dedicated build tag to include heavy dependencies only when requested. Corresponding run targets and help documentation are also updated. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L17-R17) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R27-R36) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R47-R51) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L175-R194)
* Implements conditional compilation for SBOM and vulnerability scanning tools using Go build tags, providing stub implementations when the tag is not set to avoid unnecessary bloat. [[1]](diffhunk://#diff-da0f00a10235dd3dc750fd2a2c7a1aacce835dedf63385f7931ad65e04a6497cR1-R3) [[2]](diffhunk://#diff-b2ad19c18b4f414fe1e9f786d35242f78ac7381bd190d7b9fcebd1d9e568b872R1-R7) [[3]](diffhunk://#diff-8e58747ab8e21ae0e146203660709522e5322e0478b584743fadae6beb8fef05R1-R3) [[4]](diffhunk://#diff-f8ef20cab38bc2488fec6c189fb3f06a224986d2afbb698abae6e343d4097061R1-R7) [[5]](diffhunk://#diff-2b59bdebdfee3527f942dece025123601358307c0412bb321d59e3bcfa2492edR1-R3) [[6]](diffhunk://#diff-712dbd71d1ac3796541a0992e21a3285cf1cc1fc70e0439a4d40f7aa2bf03a4fR1-R3)

**Tool registration and imports refactor:**

* Moves all tool imports into a central registry file (`internal/imports/tools.go`), simplifying `main.go` and improving maintainability and build tag handling. Documentation for adding new tools is updated accordingly. [[1]](diffhunk://#diff-2d4a4fcaadc606611bf3ebaeb361e81a41c947077cb22235a1498f32bd24fd6eR1-R28) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L24-R24) [[3]](diffhunk://#diff-29efc37539a33666774e5913ca615dea2bbf5ae3cf30eb0c26de7fd85cf98fd2L375-R387)

These changes make the build more flexible, reduce the default binary size, and clarify the process for both users and contributors.