### PR TITLE
feat: new tool - terraform documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ Please read the `README.md` for more information, and `docs/creating-new-tools.m
 
 ### Tool Categories
 
-Tools are organized into categories under `internal/tools/`, e.g:
+Tools are organised into categories under `internal/tools/`, e.g:
 - `internetsearch/` - Internet Search API integrations (web, image, news, video, local)
 - `packageversions/` - Package version checking across ecosystems (npm, python, go, java, swift, docker, github-actions, bedrock, rust)
 - `shadcnui/` - shadcn/ui component information and examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,8 @@ All tools follow this pattern:
 
 ## General Guidelines
 
-- Any tools we create must work on both macOS and Linux unless the user states otherwise (we don't care about MS Windows).
 - CRITICAL: Ensure that when running in stdio mode that we NEVER log to stdout or stderr, as this will break the MCP protocol.
+- Any tools we create must work on both macOS and Linux unless the user states otherwise (we don't care about MS Windows).
 - When testing the docprocessing tool, unless otherwise instructed always call it with "clear_file_cache": true and do not enable return_inline_only
 - If you're wanting to call a tool you've just made changes to directly (rather than using the command line approach), you have to let the user know to restart the conversation otherwise you'll only have access to the old version of the tool functions directly.
 - When adding new tools ensure they are registered in the list of available tools in the server (within their init function), ensure they have a basic unit test, and that they have docs/tools/<toolname>.md with concise, clear information about the tool and that they're mentioned in the main README.md and docs/tools/overview.md.
@@ -106,10 +106,18 @@ All tools follow this pattern:
 - We should be mindful of the risks of code injection and other security risks when parsing any information from external sources.
 - On occasion the user may ask you to build a new tool and provide reference code or information in a provided directory such as `tmp_repo_clones/<dirname>` unless specified otherwise this should only be used for reference and learning purposes, we don't ever want to use code that directory as part of the project's codebase.
 - When creating new MCP tools make sure descriptions are clear and concise as they are what is used as hints to the AI coding agent using the tool, you should also make good use of MCP's annotations.
-- You can debug the tool by running it in debug mode interactively, e.g. `rm -f debug.log; pkill -f "mcp-devtools.*" ; echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "fetch_url", "arguments": {"url": "https://go.dev", "max_length": 500, "raw": false}}}' | ./bin/mcp-devtools stdio`, or `BRAVE_API_KEY="ask the user if you need this" ./bin/mcp-devtools stdio <<< '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "brave_search", "arguments": {"type": "web", "query": "cat facts", "count": 1}}}'`
 - The mcp-go package documentation contains useful examples of using the package which you can lookup when asked to implement specific MCP features https://mcp-go.dev/servers/tools
+
+### Quick Debugging Tips
+
+- You can debug the tool by running it in debug mode interactively, e.g. `rm -f debug.log; pkill -f "mcp-devtools.*" ; echo '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "fetch_url", "arguments": {"url": "https://go.dev", "max_length": 500, "raw": false}}}' | ./bin/mcp-devtools stdio`, or `BRAVE_API_KEY="ask the user if you need this" ./bin/mcp-devtools stdio <<< '{"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "brave_search", "arguments": {"type": "web", "query": "cat facts", "count": 1}}}'`
+
+### Lint Github Actions
+```bash
+actionlint
+```
 
 ## IMPORTANT
 
 - YOU MUST ALWAYS run `make lint && make test && make build` etc... to build the project rather than gofmt, go build or test directly, and you MUST always do this before stating you've completed your changes!
-- If the serena tool is available to you, you must use serena for your semantic code retrieval and editing tools
+- CRITICAL: If the serena tool is available to you, you must use serena for your semantic code retrieval and editing tools

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ graph LR
     A --> F[Utilities]
     A --> G[Agents]
 
-    B --> B_Tools[🌐 Internet Search<br>📡 Web Fetch<br>📦 Package Search<br>📚 Package Documentation<br>🐙 GitHub<br>🎨 ShadCN UI Components<br>🔌 API Integration]
+    B --> B_Tools[🌐 Internet Search<br>📡 Web Fetch<br>📦 Package Search<br>📚 Package Documentation<br>🐙 GitHub<br>🎨 ShadCN UI Components<br>🔌 API Integration<br>☁️ AWS Documentation<br📝>Terraform Documentation]
 
     C --> C_Tools[📄 Document Processing<br>📑 PDF Processing]
 
@@ -99,18 +99,18 @@ See below for various environment variables you can set to configure specific fe
 
 These tools can be disabled by adding their function name to the `DISABLED_FUNCTIONS` environment variable in your MCP configuration.
 
-| Tool                                                             | Purpose                            | Dependencies                  | Example Usage                    |
-|------------------------------------------------------------------|------------------------------------|-------------------------------|----------------------------------|
-| **[Internet Search](docs/tools/internet-search.md)**             | Multi-provider web search          | None (Provider keys optional) | Web, image, news, video search   |
-| **[Web Fetch](docs/tools/web-fetch.md)**                         | Retrieve web content as Markdown   | None                          | Documentation and articles       |
-| **[GitHub](docs/tools/github.md)**                               | GitHub repositories and data       | None (GitHub token optional)  | Issues, PRs, repos, cloning      |
-| **[Package Documentation](docs/tools/package-documentation.md)** | Library documentation lookup       | None                          | React, Django, TensorFlow docs   |
-| **[Package Search](docs/tools/package-search.md)**               | Check package versions             | None                          | NPM, Python, Go, Java, Docker    |
-| **[Think](docs/tools/think.md)**                                 | Structured reasoning space         | None                          | Complex problem analysis         |
-| **[Find Long Files](docs/tools/find_long_files.md)**             | Identify files needing refactoring | None                          | Find files over 700 lines        |
-| **[ShadCN UI Component Library](docs/tools/shadcn-ui.md)**       | Component information              | None                          | Button, Dialog, Form components  |
-| **[American→English](docs/tools/american-to-english.md)**        | Convert to British spelling        | None                          | Organise, colour, centre         |
-| **[DevTools Help](docs/tools/devtools_help.md)**                 | Extended info about DevTools tools | None                          | Usage examples, troubleshooting  |
+| Tool                                                             | Purpose                            | Dependencies                  | Example Usage                   |
+|------------------------------------------------------------------|------------------------------------|-------------------------------|---------------------------------|
+| **[Internet Search](docs/tools/internet-search.md)**             | Multi-provider web search          | None (Provider keys optional) | Web, image, news, video search  |
+| **[Web Fetch](docs/tools/web-fetch.md)**                         | Retrieve web content as Markdown   | None                          | Documentation and articles      |
+| **[GitHub](docs/tools/github.md)**                               | GitHub repositories and data       | None (GitHub token optional)  | Issues, PRs, repos, cloning     |
+| **[Package Documentation](docs/tools/package-documentation.md)** | Library documentation lookup       | None                          | React, Django, TensorFlow docs  |
+| **[Package Search](docs/tools/package-search.md)**               | Check package versions             | None                          | NPM, Python, Go, Java, Docker   |
+| **[Think](docs/tools/think.md)**                                 | Structured reasoning space         | None                          | Complex problem analysis        |
+| **[Find Long Files](docs/tools/find_long_files.md)**             | Identify files needing refactoring | None                          | Find files over 700 lines       |
+| **[ShadCN UI Component Library](docs/tools/shadcn-ui.md)**       | Component information              | None                          | Button, Dialog, Form components |
+| **[American→English](docs/tools/american-to-english.md)**        | Convert to British spelling        | None                          | Organise, colour, centre        |
+| **[DevTools Help](docs/tools/devtools_help.md)**                 | Extended info about DevTools tools | None                          | Usage examples, troubleshooting |
 
 These tools can be enabled by setting the `ENABLE_ADDITIONAL_TOOLS` environment variable in your MCP configuration.
 
@@ -126,6 +126,7 @@ These tools can be enabled by setting the `ENABLE_ADDITIONAL_TOOLS` environment 
 | **[Document Processing](docs/tools/document-processing.md)** | Convert documents to Markdown            | `process_document`        | PDF, DOCX → Markdown with OCR             |
 | **[PDF Processing](docs/tools/pdf-processing.md)**           | Fast PDF text extraction                 | `pdf`                     | Quick PDF to Markdown                     |
 | **[AWS Documentation](docs/tools/aws_documentation.md)**     | AWS documentation search and retrieval   | `aws`                     | Search and read AWS docs, recommendations |
+| **[Terraform Documentation](docs/tools/terraform-documentation.md)** | Terraform Registry API access for providers, modules, and policies | `terraform_documentation` | Provider docs, module search, policy lookup |
 | **[Security Framework](docs/security.md)** (BETA)            | Context injection security protections   | `security`                | Content analysis, access control          |
 | **[Security Override](docs/security.md)**                    | Agent managed security warning overrides | `security_override`       | Bypass false positives                    |
 | **[API](docs/tools/api.md)**                                 | Dynamic REST API integration             | `api`                     | Configure any REST API via YAML           |
@@ -272,7 +273,7 @@ All environment variables are optional, but if you want to use specific search p
 - `DISABLED_FUNCTIONS` - Comma-separated list of functions to disable (e.g. `think,internet_search`)
 
 **Security-Sensitive Tools:**
-- `ENABLE_ADDITIONAL_TOOLS` - Comma-separated list to enable security-sensitive tools (e.g. `security,security_override,sbom,vulnerability_scan,filesystem,claude-agent,gemini-agent,generate_changelog,process_document,pdf,memory`)
+- `ENABLE_ADDITIONAL_TOOLS` - Comma-separated list to enable security-sensitive tools (e.g. `security,security_override,sbom,vulnerability_scan,filesystem,claude-agent,gemini-agent,generate_changelog,process_document,pdf,memory,terraform_documentation`)
 - `FILESYSTEM_TOOL_ALLOWED_DIRS` - Colon-separated (Unix) list of allowed directories (only for filesystem tool)
 
 **Document Processing:**

--- a/docs/creating-new-tools.md
+++ b/docs/creating-new-tools.md
@@ -11,7 +11,7 @@ The MCP DevTools server is designed to be easily extensible with new tools. This
     - [4. Result Schema](#4-result-schema)
     - [5. Caching](#5-caching)
     - [6. Security Integration](#6-security-integration)
-    - [7. Import the Tool Package](#7-import-the-tool-package)
+    - [7. Register the Tool for Import](#7-register-the-tool-for-import)
   - [Example: Hello World Tool](#example-hello-world-tool)
     - [Testing Your Tool](#testing-your-tool)
   - [Testing](#testing)

--- a/docs/tools/overview.md
+++ b/docs/tools/overview.md
@@ -48,9 +48,15 @@ Each tool has it's own documentation in this directory, detailing its purpose, a
 ```
 1. AWS Documentation (search) → Find relevant AWS guides
 2. AWS Documentation (fetch) → Get detailed AWS content
-3. Package Documentation → Access AWS Strands Agents SDK docs via resolve_library_id + get_library_docs
-4. AWS Documentation (recommend) → Discover related AWS services
-5. Memory → Store AWS configuration patterns
+```
+
+#### Terraform Documentation Research Workflow
+```
+1. Terraform Documentation (search_providers) → Find provider resources
+2. Terraform Documentation (get_provider_details) → Get detailed provider documentation
+3. Terraform Documentation (search_modules) → Find relevant modules
+4. Terraform Documentation (get_module_details) → Get module configuration examples
+5. Memory → Store Terraform configuration patterns
 ```
 
 ## Configuration Quick Start

--- a/docs/tools/terraform-documentation.md
+++ b/docs/tools/terraform-documentation.md
@@ -32,7 +32,7 @@ Find provider documentation by searching for specific services:
 ```
 
 #### Get Provider Details
-Retrieve detailed documentation using a document ID from search results:
+Retrieve detailed documentation using a numeric document ID (obtain from search_providers results):
 
 ```json
 {
@@ -40,6 +40,8 @@ Retrieve detailed documentation using a document ID from search results:
   "provider_doc_id": "8894603"
 }
 ```
+
+**Note:** The `provider_doc_id` must be a numeric ID from the provider's documentation index, not a resource name like "s3_bucket". Use `search_providers` first to find valid IDs.
 
 #### Get Latest Provider Version
 Check the latest available version for a provider:
@@ -71,9 +73,11 @@ Retrieve detailed module information including inputs, outputs, and examples:
 ```json
 {
   "action": "get_module_details",
-  "module_id": "terraform-aws-modules/vpc/aws"
+  "module_id": "terraform-aws-modules/vpc/aws/3.14.0"
 }
 ```
+
+**Note:** The `module_id` should include the full path: `namespace/name/provider/version` (e.g., `terraform-aws-modules/vpc/aws/3.14.0`).
 
 #### Get Latest Module Version
 Get the latest version of a specific module:
@@ -84,6 +88,8 @@ Get the latest version of a specific module:
   "module_id": "terraform-aws-modules/vpc/aws"
 }
 ```
+
+**Note:** For version queries, you can omit the version from the module_id.
 
 ### Policy Operations
 

--- a/docs/tools/terraform-documentation.md
+++ b/docs/tools/terraform-documentation.md
@@ -93,7 +93,7 @@ Find Terraform Sentinel policies:
 ```json
 {
   "action": "search_policies",
-  "policy_query": "security compliance"
+  "query": "security compliance"
 }
 ```
 

--- a/docs/tools/terraform-documentation.md
+++ b/docs/tools/terraform-documentation.md
@@ -1,0 +1,235 @@
+# Terraform Documentation
+
+Access Terraform Registry APIs for providers, modules, and policies with comprehensive search and documentation capabilities.
+
+## Overview
+
+The terraform_documentation tool provides unified access to the public Terraform Registry, enabling you to:
+
+- Search for and retrieve provider documentation
+- Find and explore Terraform modules
+- Search for Terraform policies
+- Get detailed documentation for resources, data sources, guides, and functions
+- Access the latest versions of providers and modules
+
+## Usage
+
+**Action-based tool:** All operations are performed through the single `terraform_documentation` tool using different `action` parameters.
+
+### Provider Operations
+
+#### Search Providers
+Find provider documentation by searching for specific services:
+
+```json
+{
+  "action": "search_providers",
+  "provider_name": "aws",
+  "provider_namespace": "hashicorp",
+  "query": "s3",
+  "provider_data_type": "resources"
+}
+```
+
+#### Get Provider Details
+Retrieve detailed documentation using a document ID from search results:
+
+```json
+{
+  "action": "get_provider_details",
+  "provider_doc_id": "8894603"
+}
+```
+
+#### Get Latest Provider Version
+Check the latest available version for a provider:
+
+```json
+{
+  "action": "get_latest_provider_version",
+  "provider_name": "aws",
+  "provider_namespace": "hashicorp"
+}
+```
+
+### Module Operations
+
+#### Search Modules
+Find Terraform modules by query:
+
+```json
+{
+  "action": "search_modules",
+  "query": "vpc aws",
+  "limit": 5
+}
+```
+
+#### Get Module Details
+Retrieve detailed module information including inputs, outputs, and examples:
+
+```json
+{
+  "action": "get_module_details",
+  "module_id": "terraform-aws-modules/vpc/aws"
+}
+```
+
+#### Get Latest Module Version
+Get the latest version of a specific module:
+
+```json
+{
+  "action": "get_latest_module_version",
+  "module_id": "terraform-aws-modules/vpc/aws"
+}
+```
+
+### Policy Operations
+
+#### Search Policies
+Find Terraform Sentinel policies:
+
+```json
+{
+  "action": "search_policies",
+  "policy_query": "security compliance"
+}
+```
+
+#### Get Policy Details
+Retrieve detailed policy information:
+
+```json
+{
+  "action": "get_policy_details",
+  "policy_id": "policy-12345"
+}
+```
+
+## Parameters
+
+### Common Parameters
+
+| Parameter | Type              | Description                             |
+|-----------|-------------------|-----------------------------------------|
+| `action`  | String (required) | The operation to perform                |
+| `query`   | String            | Search query (service slug for providers, search terms for modules/policies) |
+| `limit`   | Number            | Maximum results to return (default: 10) |
+
+### Provider Parameters
+
+| Parameter            | Type   | Description                                                                        |
+|----------------------|--------|------------------------------------------------------------------------------------|
+| `provider_name`      | String | Provider name (e.g., 'aws', 'google')                                              |
+| `provider_namespace` | String | Publisher namespace (e.g., 'hashicorp')                                            |
+| `provider_data_type` | String | Documentation type: 'resources', 'data-sources', 'functions', 'guides', 'overview' |
+| `provider_version`   | String | Specific version or 'latest'                                                       |
+| `provider_doc_id`    | String | Document ID from search results                                                    |
+
+### Module Parameters
+
+| Parameter        | Type   | Description                              |
+|------------------|--------|------------------------------------------|
+| `module_id`      | String | Full module ID (namespace/name/provider) |
+| `current_offset` | Number | Pagination offset (default: 0)           |
+
+### Policy Parameters
+
+| Parameter      | Type   | Description                   |
+|----------------|--------|-------------------------------|
+| `policy_id`    | String | Policy ID from search results |
+
+## Configuration
+
+The tool is **disabled by default** for security reasons. To enable:
+
+```json
+{
+  "env": {
+    "ENABLE_ADDITIONAL_TOOLS": "terraform_documentation"
+  }
+}
+```
+
+Or combine with other tools:
+```json
+{
+  "env": {
+    "ENABLE_ADDITIONAL_TOOLS": "terraform_documentation,memory,security"
+  }
+}
+```
+
+## Examples
+
+### Complete Provider Documentation Workflow
+
+1. Search for AWS S3 resources:
+```json
+{
+  "action": "search_providers",
+  "provider_name": "aws",
+  "provider_namespace": "hashicorp",
+  "query": "s3",
+  "provider_data_type": "resources"
+}
+```
+
+2. Use the returned `providerDocID` to get detailed documentation:
+```json
+{
+  "action": "get_provider_details",
+  "provider_doc_id": "8894603"
+}
+```
+
+### Module Discovery and Analysis
+
+1. Search for VPC modules:
+```json
+{
+  "action": "search_modules",
+  "query": "vpc aws official"
+}
+```
+
+2. Get details for a specific module:
+```json
+{
+  "action": "get_module_details",
+  "module_id": "terraform-aws-modules/vpc/aws"
+}
+```
+
+## Limitations
+
+- Only supports the public Terraform Registry (registry.terraform.io)
+- Cannot access private registries or Terraform Enterprise/Cloud
+- Read-only operations - cannot publish or modify resources
+- Rate limited by Terraform Registry API limits
+
+## Security
+
+- All HTTP requests go through security analysis
+- Only accesses public Terraform Registry APIs
+- No authentication or sensitive data required
+- Content filtering applies to returned documentation
+
+## Troubleshooting
+
+**"terraform_documentation tool is not enabled"**
+- Add 'terraform_documentation' to ENABLE_ADDITIONAL_TOOLS environment variable
+
+**"No documentation found for query"**
+- Try broader search terms or use the provider name as query
+- Check that provider_name and provider_namespace are correct
+
+**"Invalid provider_doc_id error"**
+- Always run search_providers first to get valid document IDs
+- Don't manually construct or guess document IDs
+
+**"No versions found for provider"**
+- Verify the provider exists in the public registry
+- Try 'hashicorp' namespace for official providers
+- Check provider_name spelling

--- a/internal/imports/tools.go
+++ b/internal/imports/tools.go
@@ -19,6 +19,7 @@ import (
 	_ "github.com/sammcj/mcp-devtools/internal/tools/pdf"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/securityoverride"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/shadcnui"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/terraform_documentation"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/think"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/utilities/toolhelp"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/webfetch"

--- a/internal/tools/terraform_documentation/client.go
+++ b/internal/tools/terraform_documentation/client.go
@@ -1,0 +1,533 @@
+package terraform_documentation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sammcj/mcp-devtools/internal/security"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	terraformRegistryBaseURL = "https://registry.terraform.io"
+	terraformRegistryAPIv1   = "https://registry.terraform.io/v1"
+	terraformRegistryAPIv2   = "https://registry.terraform.io/v2"
+	defaultTimeout           = 30 * time.Second
+	maxContentLength         = 1024 * 1024 // 1MB limit
+	userAgent                = "mcp-devtools-terraform-documentation/1.0"
+)
+
+// Client handles communication with the Terraform Registry API
+type Client struct {
+	httpClient *http.Client
+	logger     *logrus.Logger
+	ops        *security.Operations
+}
+
+// NewClient creates a new Terraform Registry API client
+func NewClient(logger *logrus.Logger) *Client {
+	return &Client{
+		httpClient: &http.Client{
+			Timeout: defaultTimeout,
+		},
+		logger: logger,
+		ops:    security.NewOperations("terraform_documentation"),
+	}
+}
+
+// makeRequest performs HTTP request with security checks
+func (c *Client) makeRequest(ctx context.Context, url string) ([]byte, error) {
+	// Use security operations for HTTP GET
+	safeResp, err := c.ops.SafeHTTPGet(url)
+	if err != nil {
+		if secErr, ok := err.(*security.SecurityError); ok {
+			return nil, fmt.Errorf("security block [ID: %s]: %s Check with the user if you may use security_override tool with ID %s",
+				secErr.GetSecurityID(), secErr.Error(), secErr.GetSecurityID())
+		}
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+
+	// Check for security warnings
+	if safeResp.SecurityResult != nil && safeResp.SecurityResult.Action == security.ActionWarn {
+		c.logger.Warnf("Security warning [ID: %s]: %s", safeResp.SecurityResult.ID, safeResp.SecurityResult.Message)
+	}
+
+	return safeResp.Content, nil
+}
+
+// SearchProviders searches for provider documentation
+func (c *Client) SearchProviders(ctx context.Context, providerName, providerNamespace, serviceSlug, providerDataType, providerVersion string) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Searching providers: %s/%s, service: %s, type: %s, version: %s",
+		providerNamespace, providerName, serviceSlug, providerDataType, providerVersion)
+
+	providerName = strings.ToLower(providerName)
+	providerNamespace = strings.ToLower(providerNamespace)
+	serviceSlug = strings.ToLower(serviceSlug)
+
+	// Get latest version if not specified
+	if providerVersion == "" || providerVersion == "latest" {
+		latestVersion, err := c.getLatestProviderVersionInternal(ctx, providerNamespace, providerName)
+		if err != nil {
+			return nil, fmt.Errorf("getting latest provider version: %w", err)
+		}
+		providerVersion = latestVersion
+	}
+
+	// Check if we need to use v2 API for guides, functions, or overview
+	if isV2ProviderDataType(providerDataType) {
+		content, err := c.getProviderDetailsV2(ctx, providerNamespace, providerName, providerVersion, providerDataType)
+		if err != nil {
+			return nil, fmt.Errorf("getting provider details from v2 API: %w", err)
+		}
+		fullContent := fmt.Sprintf("# %s provider docs\n\n%s", providerName, content)
+		result := map[string]interface{}{
+			"content": fullContent,
+		}
+		jsonBytes, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal result: %w", err)
+		}
+		return mcp.NewToolResultText(string(jsonBytes)), nil
+	}
+
+	// For resources/data-sources, use the v1 API
+	apiURL := fmt.Sprintf("%s/providers/%s/%s/%s", terraformRegistryAPIv1, providerNamespace, providerName, providerVersion)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching provider documentation: %w", err)
+	}
+
+	var providerDocs ProviderDocs
+	if err := json.Unmarshal(response, &providerDocs); err != nil {
+		return nil, fmt.Errorf("unmarshalling provider docs: %w", err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Available Documentation (top matches) for %s in Terraform provider %s/%s version: %s\n\n",
+		providerDataType, providerNamespace, providerName, providerVersion))
+	builder.WriteString("Each result includes:\n- providerDocID: tfprovider-compatible identifier\n- Title: Service or resource name\n- Category: Type of document\n- Description: Brief summary of the document\n")
+	builder.WriteString("For best results, select libraries based on the service_slug match and category of information requested.\n\n---\n\n")
+
+	contentAvailable := false
+	for _, doc := range providerDocs.Docs {
+		if doc.Language == "hcl" && doc.Category == providerDataType {
+			if containsSlug(doc.Slug, serviceSlug) || containsSlug(fmt.Sprintf("%s_%s", providerName, doc.Slug), serviceSlug) {
+				contentAvailable = true
+				descriptionSnippet, err := c.getContentSnippet(ctx, doc.ID)
+				if err != nil {
+					c.logger.Warnf("Error fetching content snippet for provider doc ID: %s: %v", doc.ID, err)
+				}
+				builder.WriteString(fmt.Sprintf("- providerDocID: %s\n- Title: %s\n- Category: %s\n- Description: %s\n---\n",
+					doc.ID, doc.Title, doc.Category, descriptionSnippet))
+			}
+		}
+	}
+
+	if !contentAvailable {
+		return nil, fmt.Errorf("no documentation found for service_slug %s, provide a more relevant service_slug or use the provider_name for its value", serviceSlug)
+	}
+
+	result := map[string]interface{}{
+		"content": builder.String(),
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// GetProviderDetails gets detailed provider documentation
+func (c *Client) GetProviderDetails(ctx context.Context, providerDocID string) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Getting provider details for doc ID: %s", providerDocID)
+
+	if _, err := strconv.Atoi(providerDocID); err != nil {
+		return nil, fmt.Errorf("provider_doc_id must be a valid number: %s", providerDocID)
+	}
+
+	apiURL := fmt.Sprintf("%s/provider-docs/%s", terraformRegistryAPIv2, providerDocID)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching provider documentation: %w", err)
+	}
+
+	var docResponse ProviderResourceDetails
+	if err := json.Unmarshal(response, &docResponse); err != nil {
+		return nil, fmt.Errorf("unmarshalling provider documentation: %w", err)
+	}
+
+	content := fmt.Sprintf("# %s\n\n%s", docResponse.Data.Attributes.Title, docResponse.Data.Attributes.Content)
+
+	result := map[string]interface{}{
+		"content":  content,
+		"title":    docResponse.Data.Attributes.Title,
+		"category": docResponse.Data.Attributes.Category,
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// GetLatestProviderVersion gets the latest version of a provider
+func (c *Client) GetLatestProviderVersion(ctx context.Context, providerNamespace, providerName string) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Getting latest version for provider: %s/%s", providerNamespace, providerName)
+
+	version, err := c.getLatestProviderVersionInternal(ctx, providerNamespace, providerName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[string]interface{}{
+		"version":  version,
+		"provider": fmt.Sprintf("%s/%s", providerNamespace, providerName),
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// SearchModules searches for Terraform modules
+func (c *Client) SearchModules(ctx context.Context, moduleQuery string, currentOffset int) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Searching modules: query=%s, offset=%d", moduleQuery, currentOffset)
+
+	params := url.Values{}
+	params.Set("q", moduleQuery)
+	params.Set("offset", strconv.Itoa(currentOffset))
+	params.Set("limit", "10")
+
+	apiURL := fmt.Sprintf("%s/modules?%s", terraformRegistryAPIv1, params.Encode())
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("searching modules: %w", err)
+	}
+
+	var moduleResponse ModuleSearchResponse
+	if err := json.Unmarshal(response, &moduleResponse); err != nil {
+		return nil, fmt.Errorf("unmarshalling module search response: %w", err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Terraform Modules Search Results for: \"%s\"\n\n", moduleQuery))
+	builder.WriteString("Each result includes:\n- moduleID: Module identifier for get_module_details\n- Name: Module name\n- Description: Module description\n- Downloads: Total download count\n- Verified: Official verification status\n- PublishedAt: Publication date\n\n---\n\n")
+
+	for _, module := range moduleResponse.Modules {
+		verified := "No"
+		if module.Verified {
+			verified = "Yes"
+		}
+
+		builder.WriteString(fmt.Sprintf("- moduleID: %s\n- Name: %s\n- Description: %s\n- Downloads: %d\n- Verified: %s\n- PublishedAt: %s\n---\n",
+			module.ID, module.Name, module.Description, module.Downloads, verified, module.PublishedAt))
+	}
+
+	result := map[string]interface{}{
+		"content": builder.String(),
+		"total":   len(moduleResponse.Modules),
+		"offset":  currentOffset,
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// GetModuleDetails gets detailed information about a module
+func (c *Client) GetModuleDetails(ctx context.Context, moduleID string) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Getting module details for: %s", moduleID)
+
+	apiURL := fmt.Sprintf("%s/modules/%s", terraformRegistryAPIv1, moduleID)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching module details: %w", err)
+	}
+
+	var moduleDetails ModuleDetails
+	if err := json.Unmarshal(response, &moduleDetails); err != nil {
+		return nil, fmt.Errorf("unmarshalling module details: %w", err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("# Terraform Module: %s\n\n", moduleDetails.Name))
+	builder.WriteString(fmt.Sprintf("**Description:** %s\n\n", moduleDetails.Description))
+	builder.WriteString(fmt.Sprintf("**Source:** %s\n", moduleDetails.Source))
+	builder.WriteString(fmt.Sprintf("**Version:** %s\n", moduleDetails.Version))
+	builder.WriteString(fmt.Sprintf("**Downloads:** %d\n", moduleDetails.Downloads))
+	builder.WriteString(fmt.Sprintf("**Verified:** %t\n\n", moduleDetails.Verified))
+
+	if len(moduleDetails.Inputs) > 0 {
+		builder.WriteString("## Inputs\n\n")
+		for _, input := range moduleDetails.Inputs {
+			builder.WriteString(fmt.Sprintf("- **%s** (%s): %s\n", input.Name, input.Type, input.Description))
+		}
+		builder.WriteString("\n")
+	}
+
+	if len(moduleDetails.Outputs) > 0 {
+		builder.WriteString("## Outputs\n\n")
+		for _, output := range moduleDetails.Outputs {
+			builder.WriteString(fmt.Sprintf("- **%s**: %s\n", output.Name, output.Description))
+		}
+		builder.WriteString("\n")
+	}
+
+	result := map[string]interface{}{
+		"content":   builder.String(),
+		"module_id": moduleID,
+		"version":   moduleDetails.Version,
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// GetLatestModuleVersion gets the latest version of a module
+func (c *Client) GetLatestModuleVersion(ctx context.Context, moduleID string) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Getting latest version for module: %s", moduleID)
+
+	apiURL := fmt.Sprintf("%s/modules/%s", terraformRegistryAPIv1, moduleID)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching module version: %w", err)
+	}
+
+	var moduleDetails ModuleDetails
+	if err := json.Unmarshal(response, &moduleDetails); err != nil {
+		return nil, fmt.Errorf("unmarshalling module details: %w", err)
+	}
+
+	result := map[string]interface{}{
+		"version":   moduleDetails.Version,
+		"module_id": moduleID,
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// SearchPolicies searches for Terraform policies
+func (c *Client) SearchPolicies(ctx context.Context, policyQuery string) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Searching policies: %s", policyQuery)
+
+	params := url.Values{}
+	params.Set("q", policyQuery)
+	params.Set("limit", "10")
+
+	apiURL := fmt.Sprintf("%s/policies?%s", terraformRegistryAPIv1, params.Encode())
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("searching policies: %w", err)
+	}
+
+	var policyResponse PolicySearchResponse
+	if err := json.Unmarshal(response, &policyResponse); err != nil {
+		return nil, fmt.Errorf("unmarshalling policy search response: %w", err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Terraform Policy Search Results for: \"%s\"\n\n", policyQuery))
+	builder.WriteString("Each result includes:\n- policyID: Policy identifier for get_policy_details\n- Name: Policy name\n- Title: Policy title\n- Downloads: Total download count\n\n---\n\n")
+
+	for _, policy := range policyResponse.Policies {
+		builder.WriteString(fmt.Sprintf("- policyID: %s\n- Name: %s\n- Title: %s\n- Downloads: %d\n---\n",
+			policy.ID, policy.Name, policy.Title, policy.Downloads))
+	}
+
+	result := map[string]interface{}{
+		"content": builder.String(),
+		"total":   len(policyResponse.Policies),
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// GetPolicyDetails gets detailed information about a policy
+func (c *Client) GetPolicyDetails(ctx context.Context, policyID string) (*mcp.CallToolResult, error) {
+	c.logger.Infof("Getting policy details for: %s", policyID)
+
+	apiURL := fmt.Sprintf("%s/policies/%s", terraformRegistryAPIv1, policyID)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("fetching policy details: %w", err)
+	}
+
+	var policyDetails PolicyDetails
+	if err := json.Unmarshal(response, &policyDetails); err != nil {
+		return nil, fmt.Errorf("unmarshalling policy details: %w", err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("# Terraform Policy: %s\n\n", policyDetails.Name))
+	builder.WriteString(fmt.Sprintf("**Title:** %s\n\n", policyDetails.Title))
+	builder.WriteString(fmt.Sprintf("**Downloads:** %d\n", policyDetails.Downloads))
+	builder.WriteString(fmt.Sprintf("**Description:**\n%s\n\n", policyDetails.Description))
+
+	result := map[string]interface{}{
+		"content":   builder.String(),
+		"policy_id": policyID,
+	}
+	jsonBytes, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal result: %w", err)
+	}
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// Helper functions
+
+func (c *Client) getLatestProviderVersionInternal(ctx context.Context, providerNamespace, providerName string) (string, error) {
+	apiURL := fmt.Sprintf("%s/providers/%s/%s/versions", terraformRegistryAPIv1, providerNamespace, providerName)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return "", fmt.Errorf("fetching provider versions: %w", err)
+	}
+
+	var versionsResponse ProviderVersionsResponse
+	if err := json.Unmarshal(response, &versionsResponse); err != nil {
+		return "", fmt.Errorf("unmarshalling provider versions: %w", err)
+	}
+
+	if len(versionsResponse.Versions) == 0 {
+		return "", fmt.Errorf("no versions found for provider %s/%s", providerNamespace, providerName)
+	}
+
+	// The first version should be the latest
+	return versionsResponse.Versions[0].Version, nil
+}
+
+func (c *Client) getProviderDetailsV2(ctx context.Context, providerNamespace, providerName, providerVersion, category string) (string, error) {
+	providerVersionID, err := c.getProviderVersionID(ctx, providerNamespace, providerName, providerVersion)
+	if err != nil {
+		return "", fmt.Errorf("getting provider version ID: %w", err)
+	}
+
+	if category == "overview" {
+		return c.getProviderOverviewDocs(ctx, providerVersionID)
+	}
+
+	params := url.Values{}
+	params.Set("filter[provider-version]", providerVersionID)
+	params.Set("filter[category]", category)
+	params.Set("filter[language]", "hcl")
+
+	apiURL := fmt.Sprintf("%s/provider-docs?%s", terraformRegistryAPIv2, params.Encode())
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return "", fmt.Errorf("getting provider documentation: %w", err)
+	}
+
+	var docsResponse ProviderDocsV2Response
+	if err := json.Unmarshal(response, &docsResponse); err != nil {
+		return "", fmt.Errorf("unmarshalling provider docs: %w", err)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("Available Documentation for %s in Terraform provider %s/%s version: %s\n\n",
+		category, providerNamespace, providerName, providerVersion))
+
+	for _, doc := range docsResponse.Data {
+		descriptionSnippet, err := c.getContentSnippet(ctx, doc.ID)
+		if err != nil {
+			c.logger.Warnf("Error fetching content snippet for provider doc ID: %s: %v", doc.ID, err)
+		}
+		builder.WriteString(fmt.Sprintf("- providerDocID: %s\n- Title: %s\n- Category: %s\n- Description: %s\n---\n",
+			doc.ID, doc.Attributes.Title, doc.Attributes.Category, descriptionSnippet))
+	}
+
+	return builder.String(), nil
+}
+
+func (c *Client) getProviderVersionID(ctx context.Context, providerNamespace, providerName, providerVersion string) (string, error) {
+	apiURL := fmt.Sprintf("%s/providers/%s/%s/versions", terraformRegistryAPIv2, providerNamespace, providerName)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return "", fmt.Errorf("fetching provider versions: %w", err)
+	}
+
+	var versionsResponse ProviderVersionsV2Response
+	if err := json.Unmarshal(response, &versionsResponse); err != nil {
+		return "", fmt.Errorf("unmarshalling provider versions: %w", err)
+	}
+
+	for _, version := range versionsResponse.Data {
+		if version.Attributes.Version == providerVersion {
+			return version.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("provider version %s not found", providerVersion)
+}
+
+func (c *Client) getProviderOverviewDocs(ctx context.Context, providerVersionID string) (string, error) {
+	apiURL := fmt.Sprintf("%s/provider-versions/%s", terraformRegistryAPIv2, providerVersionID)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return "", fmt.Errorf("fetching provider overview: %w", err)
+	}
+
+	var overviewResponse ProviderOverviewResponse
+	if err := json.Unmarshal(response, &overviewResponse); err != nil {
+		return "", fmt.Errorf("unmarshalling provider overview: %w", err)
+	}
+
+	return overviewResponse.Data.Attributes.Description, nil
+}
+
+func (c *Client) getContentSnippet(ctx context.Context, docID string) (string, error) {
+	apiURL := fmt.Sprintf("%s/provider-docs/%s", terraformRegistryAPIv2, docID)
+	response, err := c.makeRequest(ctx, apiURL)
+	if err != nil {
+		return "", fmt.Errorf("fetching provider-docs/%s: %w", docID, err)
+	}
+
+	var docDescription ProviderResourceDetails
+	if err := json.Unmarshal(response, &docDescription); err != nil {
+		return "", fmt.Errorf("unmarshalling provider-docs/%s: %w", docID, err)
+	}
+
+	content := docDescription.Data.Attributes.Content
+	// Try to extract description from markdown content
+	desc := ""
+	if start := strings.Index(content, "description: |-"); start != -1 {
+		if end := strings.Index(content[start:], "\n---"); end != -1 {
+			substring := content[start+len("description: |-") : start+end]
+			trimmed := strings.TrimSpace(substring)
+			desc = strings.ReplaceAll(trimmed, "\n", " ")
+		} else {
+			substring := content[start+len("description: |-"):]
+			trimmed := strings.TrimSpace(substring)
+			desc = strings.ReplaceAll(trimmed, "\n", " ")
+		}
+	}
+
+	if len(desc) > 300 {
+		return desc[:300] + "...", nil
+	}
+	return desc, nil
+}
+
+func isV2ProviderDataType(dataType string) bool {
+	return dataType == "guides" || dataType == "functions" || dataType == "overview"
+}
+
+func containsSlug(slug, searchSlug string) bool {
+	return strings.Contains(strings.ToLower(slug), strings.ToLower(searchSlug))
+}

--- a/internal/tools/terraform_documentation/client.go
+++ b/internal/tools/terraform_documentation/client.go
@@ -149,7 +149,7 @@ func (c *Client) GetProviderDetails(ctx context.Context, providerDocID string) (
 	c.logger.Infof("Getting provider details for doc ID: %s", providerDocID)
 
 	if _, err := strconv.Atoi(providerDocID); err != nil {
-		return nil, fmt.Errorf("provider_doc_id must be a valid number: %s", providerDocID)
+		return nil, fmt.Errorf("provider_doc_id must be a numeric ID from the provider's documentation index, not a resource name. Got: '%s' (hint: use search_providers first to find valid IDs)", providerDocID)
 	}
 
 	apiURL := fmt.Sprintf("%s/provider-docs/%s", terraformRegistryAPIv2, providerDocID)

--- a/internal/tools/terraform_documentation/models.go
+++ b/internal/tools/terraform_documentation/models.go
@@ -1,0 +1,253 @@
+package terraform_documentation
+
+import "time"
+
+// Provider-related structures
+
+// ProviderDocs represents the response from the v1 providers API
+type ProviderDocs struct {
+	ID          string        `json:"id"`
+	Owner       string        `json:"owner"`
+	Namespace   string        `json:"namespace"`
+	Name        string        `json:"name"`
+	Version     string        `json:"version"`
+	Tag         string        `json:"tag"`
+	Description string        `json:"description"`
+	Source      string        `json:"source"`
+	Published   time.Time     `json:"published_at"`
+	Downloads   int           `json:"downloads"`
+	Verified    bool          `json:"verified"`
+	Docs        []ProviderDoc `json:"docs"`
+}
+
+// ProviderDoc represents a single documentation item
+type ProviderDoc struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Path        string `json:"path"`
+	Slug        string `json:"slug"`
+	Category    string `json:"category"`
+	Language    string `json:"language"`
+	Subcategory string `json:"subcategory"`
+}
+
+// ProviderVersionsResponse represents provider versions from v1 API
+type ProviderVersionsResponse struct {
+	Versions []ProviderVersion `json:"versions"`
+}
+
+// ProviderVersion represents a single provider version
+type ProviderVersion struct {
+	Version     string     `json:"version"`
+	Protocols   []string   `json:"protocols"`
+	Platforms   []Platform `json:"platforms"`
+	PublishedAt time.Time  `json:"published_at"`
+}
+
+// Platform represents a platform for a provider version
+type Platform struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+}
+
+// ProviderVersionsV2Response represents provider versions from v2 API
+type ProviderVersionsV2Response struct {
+	Data []ProviderVersionV2 `json:"data"`
+	Meta ResponseMeta        `json:"meta"`
+}
+
+// ProviderVersionV2 represents a provider version from v2 API
+type ProviderVersionV2 struct {
+	ID         string                    `json:"id"`
+	Type       string                    `json:"type"`
+	Attributes ProviderVersionAttributes `json:"attributes"`
+}
+
+// ProviderVersionAttributes represents attributes of a provider version
+type ProviderVersionAttributes struct {
+	Version     string    `json:"version"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// ProviderDocsV2Response represents provider docs from v2 API
+type ProviderDocsV2Response struct {
+	Data []ProviderDocV2 `json:"data"`
+	Meta ResponseMeta    `json:"meta"`
+}
+
+// ProviderDocV2 represents a provider document from v2 API
+type ProviderDocV2 struct {
+	ID         string                `json:"id"`
+	Type       string                `json:"type"`
+	Attributes ProviderDocAttributes `json:"attributes"`
+}
+
+// ProviderDocAttributes represents attributes of a provider document
+type ProviderDocAttributes struct {
+	Title       string `json:"title"`
+	Category    string `json:"category"`
+	Language    string `json:"language"`
+	Subcategory string `json:"subcategory"`
+	Path        string `json:"path"`
+	Slug        string `json:"slug"`
+}
+
+// ProviderResourceDetails represents detailed provider resource documentation
+type ProviderResourceDetails struct {
+	Data ProviderResourceData `json:"data"`
+}
+
+// ProviderResourceData represents the data section of provider resource details
+type ProviderResourceData struct {
+	ID         string                     `json:"id"`
+	Type       string                     `json:"type"`
+	Attributes ProviderResourceAttributes `json:"attributes"`
+}
+
+// ProviderResourceAttributes represents the attributes of provider resource details
+type ProviderResourceAttributes struct {
+	Title       string `json:"title"`
+	Category    string `json:"category"`
+	Language    string `json:"language"`
+	Subcategory string `json:"subcategory"`
+	Path        string `json:"path"`
+	Slug        string `json:"slug"`
+	Content     string `json:"content"`
+}
+
+// ProviderOverviewResponse represents provider overview from v2 API
+type ProviderOverviewResponse struct {
+	Data ProviderOverviewData `json:"data"`
+}
+
+// ProviderOverviewData represents the data section of provider overview
+type ProviderOverviewData struct {
+	ID         string                     `json:"id"`
+	Type       string                     `json:"type"`
+	Attributes ProviderOverviewAttributes `json:"attributes"`
+}
+
+// ProviderOverviewAttributes represents the attributes of provider overview
+type ProviderOverviewAttributes struct {
+	Description string `json:"description"`
+	Source      string `json:"source"`
+	Version     string `json:"version"`
+}
+
+// Module-related structures
+
+// ModuleSearchResponse represents the response from module search
+type ModuleSearchResponse struct {
+	Modules []Module     `json:"modules"`
+	Meta    ResponseMeta `json:"meta"`
+}
+
+// Module represents a Terraform module
+type Module struct {
+	ID          string    `json:"id"`
+	Owner       string    `json:"owner"`
+	Namespace   string    `json:"namespace"`
+	Name        string    `json:"name"`
+	Version     string    `json:"version"`
+	Provider    string    `json:"provider"`
+	Description string    `json:"description"`
+	Source      string    `json:"source"`
+	Tag         string    `json:"tag"`
+	PublishedAt time.Time `json:"published_at"`
+	Downloads   int       `json:"downloads"`
+	Verified    bool      `json:"verified"`
+}
+
+// ModuleDetails represents detailed module information
+type ModuleDetails struct {
+	ID           string             `json:"id"`
+	Owner        string             `json:"owner"`
+	Namespace    string             `json:"namespace"`
+	Name         string             `json:"name"`
+	Version      string             `json:"version"`
+	Provider     string             `json:"provider"`
+	Description  string             `json:"description"`
+	Source       string             `json:"source"`
+	Tag          string             `json:"tag"`
+	PublishedAt  time.Time          `json:"published_at"`
+	Downloads    int                `json:"downloads"`
+	Verified     bool               `json:"verified"`
+	Inputs       []ModuleInput      `json:"inputs"`
+	Outputs      []ModuleOutput     `json:"outputs"`
+	Dependencies []ModuleDependency `json:"dependencies"`
+	Resources    []ModuleResource   `json:"resources"`
+}
+
+// ModuleInput represents a module input variable
+type ModuleInput struct {
+	Name        string      `json:"name"`
+	Type        string      `json:"type"`
+	Description string      `json:"description"`
+	Default     interface{} `json:"default"`
+	Required    bool        `json:"required"`
+}
+
+// ModuleOutput represents a module output
+type ModuleOutput struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ModuleDependency represents a module dependency
+type ModuleDependency struct {
+	Name    string `json:"name"`
+	Source  string `json:"source"`
+	Version string `json:"version"`
+}
+
+// ModuleResource represents a resource used by the module
+type ModuleResource struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// Policy-related structures
+
+// PolicySearchResponse represents the response from policy search
+type PolicySearchResponse struct {
+	Policies []Policy     `json:"policies"`
+	Meta     ResponseMeta `json:"meta"`
+}
+
+// Policy represents a Terraform policy
+type Policy struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	Downloads   int       `json:"downloads"`
+	PublishedAt time.Time `json:"published_at"`
+}
+
+// PolicyDetails represents detailed policy information
+type PolicyDetails struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Title       string    `json:"title"`
+	Description string    `json:"description"`
+	Downloads   int       `json:"downloads"`
+	PublishedAt time.Time `json:"published_at"`
+	Content     string    `json:"content"`
+	Readme      string    `json:"readme"`
+}
+
+// Common structures
+
+// ResponseMeta represents common metadata in API responses
+type ResponseMeta struct {
+	Pagination *Pagination `json:"pagination,omitempty"`
+}
+
+// Pagination represents pagination information
+type Pagination struct {
+	CurrentPage int `json:"current_page"`
+	NextPage    int `json:"next_page"`
+	PrevPage    int `json:"prev_page"`
+	TotalPages  int `json:"total_pages"`
+	TotalCount  int `json:"total_count"`
+}

--- a/internal/tools/terraform_documentation/terraform.go
+++ b/internal/tools/terraform_documentation/terraform.go
@@ -34,24 +34,24 @@ func (t *TerraformDocumentationTool) Definition() mcp.Tool {
 		),
 		// Common search parameter (consolidates *_query parameters)
 		mcp.WithString("query",
-			mcp.Description("Search query (for search_modules, search_policies, or service slug for search_providers)"),
+			mcp.Description("Search query (for search_modules, search_policies, or service slug for search_providers). Examples: 'vpc', 'kubernetes', 'security'"),
 		),
 		// Resource-specific ID parameters (semantically different, keep separate)
 		mcp.WithString("provider_doc_id",
-			mcp.Description("Terraform provider document ID (required for get_provider_details)"),
+			mcp.Description("Terraform provider document ID (required for get_provider_details) - must be a numeric ID from the provider's documentation index"),
 		),
 		mcp.WithString("module_id",
-			mcp.Description("Terraform module ID (required for get_module_details and get_latest_module_version)"),
+			mcp.Description("Terraform module ID (required for get_module_details and get_latest_module_version). Format: 'namespace/name/provider/version' (e.g., 'terraform-aws-modules/vpc/aws/3.14.0')"),
 		),
 		mcp.WithString("policy_id",
 			mcp.Description("Terraform policy ID (required for get_policy_details)"),
 		),
 		// Provider-specific parameters (grouped together for clarity)
 		mcp.WithString("provider_name",
-			mcp.Description("Name of the Terraform provider (required for provider actions)"),
+			mcp.Description("Name of the Terraform provider (required for all provider actions). Examples: 'aws', 'azurerm', 'google'"),
 		),
 		mcp.WithString("provider_namespace",
-			mcp.Description("Publisher namespace of the Terraform provider (required for provider actions)"),
+			mcp.Description("Publisher namespace of the Terraform provider (required for all provider actions). Examples: 'hashicorp', 'integrations'"),
 		),
 		mcp.WithString("provider_data_type",
 			mcp.Description("Type of provider documentation to retrieve"),
@@ -120,17 +120,17 @@ func (t *TerraformDocumentationTool) Execute(ctx context.Context, logger *logrus
 func (t *TerraformDocumentationTool) executeSearchProviders(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
 	providerName, ok := args["provider_name"].(string)
 	if !ok || providerName == "" {
-		return nil, fmt.Errorf("missing required parameter: provider_name")
+		return nil, fmt.Errorf("search_providers requires 'provider_name' parameter (e.g., 'aws', 'azurerm', 'google')")
 	}
 
 	providerNamespace, ok := args["provider_namespace"].(string)
 	if !ok || providerNamespace == "" {
-		return nil, fmt.Errorf("missing required parameter: provider_namespace")
+		return nil, fmt.Errorf("search_providers requires 'provider_namespace' parameter (e.g., 'hashicorp', 'integrations')")
 	}
 
 	serviceSlug, ok := args["query"].(string)
 	if !ok || serviceSlug == "" {
-		return nil, fmt.Errorf("missing required parameter: query (service slug for providers)")
+		return nil, fmt.Errorf("search_providers requires 'query' parameter for service slug (e.g., 's3', 'compute', 'networking')")
 	}
 
 	providerDataType := "resources"

--- a/internal/tools/terraform_documentation/terraform.go
+++ b/internal/tools/terraform_documentation/terraform.go
@@ -1,0 +1,303 @@
+package terraform_documentation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sammcj/mcp-devtools/internal/registry"
+	"github.com/sammcj/mcp-devtools/internal/tools"
+	"github.com/sirupsen/logrus"
+)
+
+// TerraformDocumentationTool implements the tools.Tool interface
+type TerraformDocumentationTool struct {
+	client *Client
+}
+
+// init registers the tool with the registry
+func init() {
+	registry.Register(&TerraformDocumentationTool{})
+}
+
+// Definition returns the tool's definition for MCP registration
+func (t *TerraformDocumentationTool) Definition() mcp.Tool {
+	return mcp.NewTool(
+		"terraform_documentation",
+		mcp.WithDescription("Access Terraform Registry APIs for providers, modules, and policies with search and documentation capabilities."),
+		mcp.WithString("action",
+			mcp.Required(),
+			mcp.Description("Action to perform"),
+			mcp.Enum("search_providers", "get_provider_details", "get_latest_provider_version", "search_modules", "get_module_details", "get_latest_module_version", "search_policies", "get_policy_details"),
+		),
+		// Common search parameter (consolidates *_query parameters)
+		mcp.WithString("query",
+			mcp.Description("Search query (for search_modules, search_policies, or service slug for search_providers)"),
+		),
+		// Resource-specific ID parameters (semantically different, keep separate)
+		mcp.WithString("provider_doc_id",
+			mcp.Description("Terraform provider document ID (required for get_provider_details)"),
+		),
+		mcp.WithString("module_id",
+			mcp.Description("Terraform module ID (required for get_module_details and get_latest_module_version)"),
+		),
+		mcp.WithString("policy_id",
+			mcp.Description("Terraform policy ID (required for get_policy_details)"),
+		),
+		// Provider-specific parameters (grouped together for clarity)
+		mcp.WithString("provider_name",
+			mcp.Description("Name of the Terraform provider (required for provider actions)"),
+		),
+		mcp.WithString("provider_namespace",
+			mcp.Description("Publisher namespace of the Terraform provider (required for provider actions)"),
+		),
+		mcp.WithString("provider_data_type",
+			mcp.Description("Type of provider documentation to retrieve"),
+			mcp.Enum("resources", "data-sources", "functions", "guides", "overview"),
+			mcp.DefaultString("resources"),
+		),
+		mcp.WithString("provider_version",
+			mcp.Description("Provider version (Default: 'latest', optional: specific version 'x.y.z')"),
+			mcp.DefaultString("latest"),
+		),
+		// General pagination and limits
+		mcp.WithNumber("current_offset",
+			mcp.Description("Pagination offset for search operations"),
+			mcp.DefaultNumber(0),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("Maximum number of results to return for search operations"),
+			mcp.DefaultNumber(5),
+		),
+	)
+}
+
+// Execute executes the tool's logic
+func (t *TerraformDocumentationTool) Execute(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+
+	// Initialise client if needed
+	if t.client == nil {
+		t.client = NewClient(logger)
+	}
+
+	// Parse action parameter
+	action, ok := args["action"].(string)
+	if !ok {
+		return nil, fmt.Errorf("missing required parameter: action")
+	}
+
+	action = strings.TrimSpace(action)
+	if action == "" {
+		return nil, fmt.Errorf("action parameter cannot be empty")
+	}
+
+	// Dispatch to appropriate handler
+	switch action {
+	case "search_providers":
+		return t.executeSearchProviders(ctx, logger, cache, args)
+	case "get_provider_details":
+		return t.executeGetProviderDetails(ctx, logger, cache, args)
+	case "get_latest_provider_version":
+		return t.executeGetLatestProviderVersion(ctx, logger, cache, args)
+	case "search_modules":
+		return t.executeSearchModules(ctx, logger, cache, args)
+	case "get_module_details":
+		return t.executeGetModuleDetails(ctx, logger, cache, args)
+	case "get_latest_module_version":
+		return t.executeGetLatestModuleVersion(ctx, logger, cache, args)
+	case "search_policies":
+		return t.executeSearchPolicies(ctx, logger, cache, args)
+	case "get_policy_details":
+		return t.executeGetPolicyDetails(ctx, logger, cache, args)
+	default:
+		return nil, fmt.Errorf("invalid action: %s", action)
+	}
+}
+
+// executeSearchProviders handles search_providers action
+func (t *TerraformDocumentationTool) executeSearchProviders(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	providerName, ok := args["provider_name"].(string)
+	if !ok || providerName == "" {
+		return nil, fmt.Errorf("missing required parameter: provider_name")
+	}
+
+	providerNamespace, ok := args["provider_namespace"].(string)
+	if !ok || providerNamespace == "" {
+		return nil, fmt.Errorf("missing required parameter: provider_namespace")
+	}
+
+	serviceSlug, ok := args["query"].(string)
+	if !ok || serviceSlug == "" {
+		return nil, fmt.Errorf("missing required parameter: query (service slug for providers)")
+	}
+
+	providerDataType := "resources"
+	if pdt, ok := args["provider_data_type"].(string); ok && pdt != "" {
+		providerDataType = pdt
+	}
+
+	providerVersion := "latest"
+	if pv, ok := args["provider_version"].(string); ok && pv != "" {
+		providerVersion = pv
+	}
+
+	return t.client.SearchProviders(ctx, providerName, providerNamespace, serviceSlug, providerDataType, providerVersion)
+}
+
+// executeGetProviderDetails handles get_provider_details action
+func (t *TerraformDocumentationTool) executeGetProviderDetails(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	providerDocID, ok := args["provider_doc_id"].(string)
+	if !ok || providerDocID == "" {
+		return nil, fmt.Errorf("missing required parameter: provider_doc_id")
+	}
+
+	return t.client.GetProviderDetails(ctx, providerDocID)
+}
+
+// executeGetLatestProviderVersion handles get_latest_provider_version action
+func (t *TerraformDocumentationTool) executeGetLatestProviderVersion(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	providerName, ok := args["provider_name"].(string)
+	if !ok || providerName == "" {
+		return nil, fmt.Errorf("missing required parameter: provider_name")
+	}
+
+	providerNamespace, ok := args["provider_namespace"].(string)
+	if !ok || providerNamespace == "" {
+		return nil, fmt.Errorf("missing required parameter: provider_namespace")
+	}
+
+	return t.client.GetLatestProviderVersion(ctx, providerNamespace, providerName)
+}
+
+// executeSearchModules handles search_modules action
+func (t *TerraformDocumentationTool) executeSearchModules(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	moduleQuery, ok := args["query"].(string)
+	if !ok || moduleQuery == "" {
+		return nil, fmt.Errorf("missing required parameter: query")
+	}
+
+	currentOffset := 0
+	if co, ok := args["current_offset"].(float64); ok {
+		currentOffset = int(co)
+	}
+
+	return t.client.SearchModules(ctx, moduleQuery, currentOffset)
+}
+
+// executeGetModuleDetails handles get_module_details action
+func (t *TerraformDocumentationTool) executeGetModuleDetails(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	moduleID, ok := args["module_id"].(string)
+	if !ok || moduleID == "" {
+		return nil, fmt.Errorf("missing required parameter: module_id")
+	}
+
+	return t.client.GetModuleDetails(ctx, moduleID)
+}
+
+// executeGetLatestModuleVersion handles get_latest_module_version action
+func (t *TerraformDocumentationTool) executeGetLatestModuleVersion(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	moduleID, ok := args["module_id"].(string)
+	if !ok || moduleID == "" {
+		return nil, fmt.Errorf("missing required parameter: module_id")
+	}
+
+	return t.client.GetLatestModuleVersion(ctx, moduleID)
+}
+
+// executeSearchPolicies handles search_policies action
+func (t *TerraformDocumentationTool) executeSearchPolicies(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	policyQuery, ok := args["query"].(string)
+	if !ok || policyQuery == "" {
+		return nil, fmt.Errorf("missing required parameter: query")
+	}
+
+	return t.client.SearchPolicies(ctx, policyQuery)
+}
+
+// executeGetPolicyDetails handles get_policy_details action
+func (t *TerraformDocumentationTool) executeGetPolicyDetails(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]interface{}) (*mcp.CallToolResult, error) {
+	policyID, ok := args["policy_id"].(string)
+	if !ok || policyID == "" {
+		return nil, fmt.Errorf("missing required parameter: policy_id")
+	}
+
+	return t.client.GetPolicyDetails(ctx, policyID)
+}
+
+// ProvideExtendedInfo provides extended help information for the tool
+func (t *TerraformDocumentationTool) ProvideExtendedInfo() *tools.ExtendedHelp {
+	return &tools.ExtendedHelp{
+		Examples: []tools.ToolExample{
+			{
+				Description: "Search for AWS provider resources",
+				Arguments: map[string]interface{}{
+					"action":             "search_providers",
+					"provider_name":      "aws",
+					"provider_namespace": "hashicorp",
+					"query":              "s3",
+					"provider_data_type": "resources",
+				},
+				ExpectedResult: "Returns list of AWS provider resources related to S3 with document IDs",
+			},
+			{
+				Description: "Get specific provider documentation",
+				Arguments: map[string]interface{}{
+					"action":          "get_provider_details",
+					"provider_doc_id": "8894603",
+				},
+				ExpectedResult: "Returns detailed documentation for the specified provider resource in markdown format",
+			},
+			{
+				Description: "Search for Terraform modules",
+				Arguments: map[string]interface{}{
+					"action": "search_modules",
+					"query":  "vpc aws",
+					"limit":  5,
+				},
+				ExpectedResult: "Returns list of Terraform modules matching the VPC query with module IDs",
+			},
+			{
+				Description: "Get module details",
+				Arguments: map[string]interface{}{
+					"action":    "get_module_details",
+					"module_id": "terraform-aws-modules/vpc/aws",
+				},
+				ExpectedResult: "Returns detailed module documentation including inputs, outputs, and examples",
+			},
+		},
+		CommonPatterns: []string{
+			"Always use search_providers before get_provider_details to get valid document IDs",
+			"Always use search_modules before get_module_details to get valid module IDs",
+			"Provider actions require provider_name and provider_namespace parameters",
+			"Use query parameter for service slug (providers), search terms (modules/policies)",
+			"All search operations support pagination using current_offset parameter",
+		},
+		Troubleshooting: []tools.TroubleshootingTip{
+			{
+				Problem:  "Invalid provider_doc_id error",
+				Solution: "First run search_providers to get valid provider document IDs, don't guess the ID",
+			},
+			{
+				Problem:  "No provider documentation found",
+				Solution: "Check provider_name and provider_namespace are correct, try 'hashicorp' namespace for official providers",
+			},
+			{
+				Problem:  "Module search returns no results",
+				Solution: "Try broader search terms, check module_query spelling, or search without specific provider names",
+			},
+		},
+		ParameterDetails: map[string]string{
+			"action":             "Determines which Terraform Registry API to call - providers, modules, or policies",
+			"query":              "Unified search parameter - service slug for providers (e.g., 's3'), search terms for modules/policies",
+			"provider_name":      "The provider name (e.g., 'aws', 'google', 'azurerm') - usually matches the provider binary name",
+			"provider_namespace": "The publisher namespace (e.g., 'hashicorp', 'integrations') - check Terraform Registry for correct namespace",
+			"provider_doc_id":    "Numeric ID from search_providers results - required for getting specific documentation",
+			"module_id":          "Full module identifier in format 'namespace/name/provider' (e.g., 'terraform-aws-modules/vpc/aws')",
+			"policy_id":          "Policy identifier from search_policies results - required for getting specific policy details",
+		},
+		WhenToUse:    "Use when you need Terraform provider documentation, module information, or policy details from the public Terraform Registry",
+		WhenNotToUse: "Don't use for local Terraform state inspection, private registries, or Terraform CLI operations",
+	}
+}


### PR DESCRIPTION
feat: new tool - `terraform_documentation`

This pull request adds support for a new "Terraform Documentation" tool, providing unified access to the public Terraform Registry for providers, modules, and policies.

This tool is disabled by default.