### PR TITLE
change: BREAKING: Set shadcn, murican_to_english to disabled by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Set working directory
 WORKDIR /app

--- a/docs/creating-new-tools.md
+++ b/docs/creating-new-tools.md
@@ -552,6 +552,7 @@ Tools with extended help:
 - Rather than creating lots of tools for one purpose / provider, instead favour creating a single tool with multiple functions and parameters.
 - Tools should have fast, concise unit tests that do not rely on external dependencies or services.
 - No tool should ever log to stdout or stderr when the MCP server is running in stdio mode as this breaks the MCP protocol.
+- Consider if the tool should be enabled or disabled by default, if unsure - make it disabled by default following existing patterns (Don't forget to enable it in tests).
 - You should update docs/tools/overview.md with adding or changing a tool.
 - **SECURITY**: All tools that access files or make HTTP requests MUST integrate with the security system. See [Security Integration](#6-security-integration) above and [Security System Documentation](security.md) for details.
 - Follow least privilege security principles.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -162,11 +162,14 @@ func requiresEnablement(toolName string) bool {
 		"vulnerability_scan",
 		"claude-agent",
 		"gemini-agent",
+		"q-developer-agent",
 		"generate_changelog",
 		"process_document",
 		"pdf",
 		"memory",
 		"aws",
+		"shadcn",
+		"murican_to_english",
 	}
 
 	// Normalize the tool name (lowercase, replace underscores with hyphens)

--- a/internal/tools/m2e/m2e.go
+++ b/internal/tools/m2e/m2e.go
@@ -64,6 +64,11 @@ Inline mode: Provide text parameter instead to get converted text returned direc
 
 // Execute executes the m2e tool
 func (m *M2ETool) Execute(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]any) (*mcp.CallToolResult, error) {
+	// Check if murican_to_english tool is enabled (disabled by default)
+	if !tools.IsToolEnabled("murican_to_english") {
+		return nil, fmt.Errorf("murican_to_english tool is not enabled. Set ENABLE_ADDITIONAL_TOOLS environment variable to include 'murican_to_english'")
+	}
+
 	// Parse and validate parameters
 	request, err := m.parseRequest(args)
 	if err != nil {

--- a/internal/tools/shadcnui/unified_shadcn.go
+++ b/internal/tools/shadcnui/unified_shadcn.go
@@ -64,6 +64,11 @@ Examples:
 
 // Execute executes the unified shadcn tool
 func (t *UnifiedShadcnTool) Execute(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]any) (*mcp.CallToolResult, error) {
+	// Check if shadcn tool is enabled (disabled by default)
+	if !tools.IsToolEnabled("shadcn") {
+		return nil, fmt.Errorf("shadcn tool is not enabled. Set ENABLE_ADDITIONAL_TOOLS environment variable to include 'shadcn'")
+	}
+
 	// Parse action (required)
 	action, ok := args["action"].(string)
 	if !ok || action == "" {

--- a/tests/testutils/helpers.go
+++ b/tests/testutils/helpers.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"sync"
 	"testing"
 
@@ -61,6 +62,22 @@ func AssertNotNil(t *testing.T, value any) {
 	if value == nil {
 		t.Fatal("Expected non-nil value")
 	}
+}
+
+// AssertNil asserts that a value is nil
+// AssertNil asserts that a value is nil
+// AssertNil asserts that a value is nil
+func AssertNil(t *testing.T, value any) {
+	t.Helper()
+	if value == nil {
+		return // Test passes
+	}
+	// Handle the case where value is a nil pointer wrapped in an interface
+	rv := reflect.ValueOf(value)
+	if rv.Kind() == reflect.Ptr && rv.IsNil() {
+		return // Test passes
+	}
+	t.Fatalf("Expected nil value, got %v (type: %T)", value, value)
 }
 
 // AssertEqual fails the test if expected != actual

--- a/tests/tools/m2e_test.go
+++ b/tests/tools/m2e_test.go
@@ -28,7 +28,32 @@ func TestM2ETool_Definition(t *testing.T) {
 	testutils.AssertNotNil(t, definition.InputSchema)
 }
 
+func TestM2ETool_Execute_ToolDisabled(t *testing.T) {
+	// Ensure murican_to_english tool is disabled by default
+	_ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS")
+
+	tool := &m2e.M2ETool{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{
+		"text": "The color of the organization's behavior was analyzed.",
+	}
+
+	result, err := tool.Execute(ctx, logger, cache, args)
+
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "murican_to_english tool is not enabled")
+	testutils.AssertErrorContains(t, err, "Set ENABLE_ADDITIONAL_TOOLS environment variable to include 'murican_to_english'")
+	testutils.AssertNil(t, result)
+}
+
 func TestM2ETool_Execute_InlineMode_ValidInput(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -66,6 +91,10 @@ func TestM2ETool_Execute_InlineMode_ValidInput(t *testing.T) {
 }
 
 func TestM2ETool_Execute_InlineMode_EmptyText(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -82,6 +111,10 @@ func TestM2ETool_Execute_InlineMode_EmptyText(t *testing.T) {
 }
 
 func TestM2ETool_Execute_InlineMode_TrulyEmptyText(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -98,6 +131,10 @@ func TestM2ETool_Execute_InlineMode_TrulyEmptyText(t *testing.T) {
 }
 
 func TestM2ETool_Execute_InlineMode_ExcessivelyLongText(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -122,6 +159,10 @@ func TestM2ETool_Execute_InlineMode_ExcessivelyLongText(t *testing.T) {
 }
 
 func TestM2ETool_Execute_CustomMaxLengthEnvironmentVariable(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	// Save original environment variable
 	originalValue := os.Getenv("M2E_MAX_LENGTH")
 	defer func() {
@@ -169,6 +210,10 @@ func TestM2ETool_Execute_CustomMaxLengthEnvironmentVariable(t *testing.T) {
 }
 
 func TestM2ETool_Execute_FileMode_ValidFile(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	// Create a temporary file with American text
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "test.txt")
@@ -211,6 +256,10 @@ func TestM2ETool_Execute_FileMode_ValidFile(t *testing.T) {
 }
 
 func TestM2ETool_Execute_FileMode_ExcessivelyLargeFile(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	// Create a temporary file with content exceeding the limit
 	tempDir := t.TempDir()
 	tempFile := filepath.Join(tempDir, "large_test.txt")
@@ -244,6 +293,10 @@ func TestM2ETool_Execute_FileMode_ExcessivelyLargeFile(t *testing.T) {
 }
 
 func TestM2ETool_Execute_MissingParameters(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -258,6 +311,10 @@ func TestM2ETool_Execute_MissingParameters(t *testing.T) {
 }
 
 func TestM2ETool_Execute_BothParameters(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -275,6 +332,10 @@ func TestM2ETool_Execute_BothParameters(t *testing.T) {
 }
 
 func TestM2ETool_Execute_InvalidFilePath(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -291,6 +352,10 @@ func TestM2ETool_Execute_InvalidFilePath(t *testing.T) {
 }
 
 func TestM2ETool_Execute_SmartQuotesOption(t *testing.T) {
+	// Enable the murican_to_english tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "murican_to_english")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &m2e.M2ETool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()

--- a/tests/tools/shadcnui_test.go
+++ b/tests/tools/shadcnui_test.go
@@ -30,7 +30,32 @@ func TestUnifiedShadcnTool_Definition(t *testing.T) {
 	testutils.AssertNotNil(t, definition.InputSchema)
 }
 
+func TestUnifiedShadcnTool_Execute_ToolDisabled(t *testing.T) {
+	// Ensure shadcn tool is disabled by default
+	_ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS")
+
+	tool := &shadcnui.UnifiedShadcnTool{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{
+		"action": "list",
+	}
+
+	result, err := tool.Execute(ctx, logger, cache, args)
+
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "shadcn tool is not enabled")
+	testutils.AssertErrorContains(t, err, "Set ENABLE_ADDITIONAL_TOOLS environment variable to include 'shadcn'")
+	testutils.AssertNil(t, result)
+}
+
 func TestUnifiedShadcnTool_Execute_MissingAction(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -45,6 +70,10 @@ func TestUnifiedShadcnTool_Execute_MissingAction(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_EmptyAction(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -61,6 +90,10 @@ func TestUnifiedShadcnTool_Execute_EmptyAction(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_InvalidActionType(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -77,6 +110,10 @@ func TestUnifiedShadcnTool_Execute_InvalidActionType(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_InvalidAction(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -93,6 +130,10 @@ func TestUnifiedShadcnTool_Execute_InvalidAction(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_SearchMissingQuery(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -109,6 +150,10 @@ func TestUnifiedShadcnTool_Execute_SearchMissingQuery(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_SearchEmptyQuery(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -126,6 +171,10 @@ func TestUnifiedShadcnTool_Execute_SearchEmptyQuery(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_DetailsMissingComponentName(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -142,6 +191,10 @@ func TestUnifiedShadcnTool_Execute_DetailsMissingComponentName(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_DetailsEmptyComponentName(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -159,6 +212,10 @@ func TestUnifiedShadcnTool_Execute_DetailsEmptyComponentName(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_ExamplesMissingComponentName(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -175,6 +232,10 @@ func TestUnifiedShadcnTool_Execute_ExamplesMissingComponentName(t *testing.T) {
 }
 
 func TestUnifiedShadcnTool_Execute_ExamplesEmptyComponentName(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -278,6 +339,10 @@ func TestUnifiedShadcnTool_CacheBehavior(t *testing.T) {
 
 // Test action parameter validation comprehensively
 func TestUnifiedShadcnTool_ActionValidation(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	invalidActions := []string{"invalid", "notfound", "wrong", ""}
 
 	tool := &shadcnui.UnifiedShadcnTool{}
@@ -304,6 +369,10 @@ func TestUnifiedShadcnTool_ActionValidation(t *testing.T) {
 
 // Test parameter type validation
 func TestUnifiedShadcnTool_ParameterTypes(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()
@@ -351,6 +420,10 @@ func TestUnifiedShadcnTool_ParameterTypes(t *testing.T) {
 
 // Test edge cases
 func TestUnifiedShadcnTool_EdgeCases(t *testing.T) {
+	// Enable the shadcn tool for testing
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "shadcn")
+	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
+
 	tool := &shadcnui.UnifiedShadcnTool{}
 	logger := testutils.CreateTestLogger()
 	cache := testutils.CreateTestCache()


### PR DESCRIPTION
- BREAKING CHANGE: Set `shadcn` and `murican_to_english` to disabled by default.

You can enable these by adding them to the list of `ENABLE_ADDITIONAL_TOOLS` in your environment.