### PR TITLE
feat: new tool - calculator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ fmt:
 lint:
 	gofmt -w -s .
 	golangci-lint run
-	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -test ./...
+	go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
 
 # Install dependencies
 .PHONY: deps

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ graph LR
 
     E --> E_Tools[🧠 Think Tool<br>🔢 Sequential Thinking<br>🕸️ Memory Graph]
 
-    F --> F_Tools[h<br>🧮 Calculator🇬🇧 American→English<br>📁 Filesystem<br>📝 Changelog Generation]
+    F --> F_Tools[🧮 Calculator<br>🇬🇧 American→English<br>📁 Filesystem<br>📝 Changelog Generation]
 
     G --> G_Tools[🤖 Claude Code<br>✨ Gemini CLI<br>🅰️ Q Developer]
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ graph LR
 
     E --> E_Tools[🧠 Think Tool<br>🔢 Sequential Thinking<br>🕸️ Memory Graph]
 
-    F --> F_Tools[🇬🇧 American→English<br>📁 Filesystem<br>📝 Changelog Generation]
+    F --> F_Tools[h<br>🧮 Calculator🇬🇧 American→English<br>📁 Filesystem<br>📝 Changelog Generation]
 
     G --> G_Tools[🤖 Claude Code<br>✨ Gemini CLI<br>🅰️ Q Developer]
 
@@ -85,7 +85,7 @@ xattr -r -d com.apple.quarantine ${GOPATH}/bin/mcp-devtools
       "type": "stdio",
       "command": "/path/to/mcp-devtools",
       "env": {
-        "DISABLED_FUNCTIONS": "security", // Optional, disable specific tools if not needed
+        "DISABLED_FUNCTIONS": "think", // Optional, disable specific tools if not needed
         "ENABLE_ADDITIONAL_TOOLS": "security,security_override,sbom,vulnerability_scan,memory" // Optional, enable security and analysis tools
       }
     }
@@ -108,30 +108,36 @@ These tools can be disabled by adding their function name to the `DISABLED_FUNCT
 | **[Package Search](docs/tools/package-search.md)**               | Check package versions             | None                          | NPM, Python, Go, Java, Docker   |
 | **[Think](docs/tools/think.md)**                                 | Structured reasoning space         | None                          | Complex problem analysis        |
 | **[Find Long Files](docs/tools/find_long_files.md)**             | Identify files needing refactoring | None                          | Find files over 700 lines       |
-| **[ShadCN UI Component Library](docs/tools/shadcn-ui.md)**       | Component information              | None                          | Button, Dialog, Form components |
-| **[American→English](docs/tools/american-to-english.md)**        | Convert to British spelling        | None                          | Organise, colour, centre        |
+| **[Calculator](docs/tools/calculator.md)**                       | Basic arithmetic calculations      | None                          | 2 + 3 * 4, batch processing     |
 | **[DevTools Help](docs/tools/devtools_help.md)**                 | Extended info about DevTools tools | None                          | Usage examples, troubleshooting |
 
 These tools can be enabled by setting the `ENABLE_ADDITIONAL_TOOLS` environment variable in your MCP configuration.
 
-| Tool                                                         | Purpose                                  | `ENABLE_ADDITIONAL_TOOLS` | Example Usage                             |
-|--------------------------------------------------------------|------------------------------------------|---------------------------|-------------------------------------------|
-| **[Filesystem](docs/tools/filesystem.md)**                   | File and directory operations            | `filesystem`              | Read, write, edit, search files           |
-| **[Claude Agent](docs/tools/claude-agent.md)**               | Claude Code CLI Agent                    | `claude-agent`            | Code analysis, generation                 |
-| **[Gemini Agent](docs/tools/gemini-agent.md)**               | Gemini CLI Agent                         | `gemini-agent`            | Code analysis, generation                 |
-| **[Q Developer Agent](docs/tools/q-developer-agent.md)**     | AWS Q Developer CLI Agent                | `q-developer-agent`       | AWS-focused code analysis, generation     |
-| **[Memory](docs/tools/memory.md)**                           | Persistent knowledge graphs              | `memory`                  | Store entities and relationships          |
-| **[SBOM Generation](docs/tools/sbom.md)**                    | Generate Software Bill of Materials      | `sbom`                    | Analyse project dependencies              |
-| **[Vulnerability Scan](docs/tools/vulnerability_scan.md)**   | Security vulnerability scanning          | `vulnerability_scan`      | Find security issues                      |
-| **[Generate Changelog](docs/tools/changelog.md)**            | Generate changelogs from git commits     | `generate_changelog`      | Release notes from local/remote repos     |
-| **[Document Processing](docs/tools/document-processing.md)** | Convert documents to Markdown            | `process_document`        | PDF, DOCX → Markdown with OCR             |
-| **[PDF Processing](docs/tools/pdf-processing.md)**           | Fast PDF text extraction                 | `pdf`                     | Quick PDF to Markdown                     |
-| **[AWS Documentation](docs/tools/aws_documentation.md)**     | AWS documentation search and retrieval   | `aws`                     | Search and read AWS docs, recommendations |
+| Tool                                                                 | Purpose                                                            | `ENABLE_ADDITIONAL_TOOLS` | Example Usage                               |
+|----------------------------------------------------------------------|--------------------------------------------------------------------|---------------------------|---------------------------------------------|
+| **[American→English](docs/tools/american-to-english.md)**            | Convert to British spelling                                        | `murican_to_english`      | Organise, colour, centre                    |
+| **[ShadCN UI Component Library](docs/tools/shadcn-ui.md)**           | Component information                                              | `shadcn`                  | Button, Dialog, Form components             |
+| **[Memory](docs/tools/memory.md)**                                   | Persistent knowledge graphs                                        | `memory`                  | Store entities and relationships            |
+| **[SBOM Generation](docs/tools/sbom.md)**                            | Generate Software Bill of Materials                                | `sbom`                    | Analyse project dependencies                |
+| **[Vulnerability Scan](docs/tools/vulnerability_scan.md)**           | Security vulnerability scanning                                    | `vulnerability_scan`      | Find security issues                        |
+| **[Generate Changelog](docs/tools/changelog.md)**                    | Generate changelogs from git commits                               | `generate_changelog`      | Release notes from local/remote repos       |
+| **[Document Processing](docs/tools/document-processing.md)**         | Convert documents to Markdown                                      | `process_document`        | PDF, DOCX → Markdown with OCR               |
+| **[PDF Processing](docs/tools/pdf-processing.md)**                   | Fast PDF text extraction                                           | `pdf`                     | Quick PDF to Markdown                       |
+| **[AWS Documentation](docs/tools/aws_documentation.md)**             | AWS documentation search and retrieval                             | `aws`                     | Search and read AWS docs, recommendations   |
 | **[Terraform Documentation](docs/tools/terraform-documentation.md)** | Terraform Registry API access for providers, modules, and policies | `terraform_documentation` | Provider docs, module search, policy lookup |
-| **[Security Framework](docs/security.md)** (BETA)            | Context injection security protections   | `security`                | Content analysis, access control          |
-| **[Security Override](docs/security.md)**                    | Agent managed security warning overrides | `security_override`       | Bypass false positives                    |
-| **[Sequential Thinking](docs/tools/sequential-thinking.md)** | Dynamic problem-solving through structured thoughts | `sequential-thinking` | Step-by-step analysis, revision, branching |
-| **[API](docs/tools/api.md)**                                 | Dynamic REST API integration             | `api`                     | Configure any REST API via YAML           |
+| **[Security Framework](docs/security.md)** (BETA)                    | Context injection security protections                             | `security`                | Content analysis, access control            |
+| **[Security Override](docs/security.md)**                            | Agent managed security warning overrides                           | `security_override`       | Bypass false positives                      |
+| **[Sequential Thinking](docs/tools/sequential-thinking.md)**         | Dynamic problem-solving through structured thoughts                | `sequential-thinking`     | Step-by-step analysis, revision, branching  |
+| **[API to MCP](docs/tools/api.md)**                                  | Dynamic REST API integration                                       | `api`                     | Configure any REST API via YAML             |
+| **[Filesystem](docs/tools/filesystem.md)**                           | File and directory operations                                      | `filesystem`              | Read, write, edit, search files             |
+
+**Agents as Tools** - In addition to the above tools, MCP DevTools can provide access to AI agents as tools by integrating with external LLMs.
+
+| Agent                                                    | Purpose                   | `ENABLE_ADDITIONAL_TOOLS` |
+|----------------------------------------------------------|---------------------------|---------------------------|
+| **[Claude Agent](docs/tools/claude-agent.md)**           | Claude Code CLI Agent     | `claude-agent`            |
+| **[Gemini Agent](docs/tools/gemini-agent.md)**           | Gemini CLI Agent          | `gemini-agent`            |
+| **[Q Developer Agent](docs/tools/q-developer-agent.md)** | AWS Q Developer CLI Agent | `q-developer-agent`       |
 
 👉 **[See detailed tool documentation](docs/tools/overview.md)**
 

--- a/docs/tools/calculator.md
+++ b/docs/tools/calculator.md
@@ -1,0 +1,270 @@
+# Calculator Tool
+
+The Calculator tool provides basic arithmetic computation capabilities for AI agents that need to perform mathematical calculations accurately.
+
+## Purpose
+
+AI agents can use this tool when they need to:
+- Perform basic arithmetic operations
+- Calculate complex expressions with proper order of operations
+- Ensure mathematical accuracy in their computations
+- Handle both integer and decimal number calculations
+
+## Usage
+
+### Basic Operations
+
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "2 + 3"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "expression": "2 + 3",
+  "result": 5
+}
+```
+
+### Supported Operations
+
+- **Addition**: `+`
+- **Subtraction**: `-`
+- **Multiplication**: `*`
+- **Division**: `/`
+- **Modulo**: `%`
+- **Parentheses**: `()` for grouping
+
+### Order of Operations
+
+The calculator follows standard mathematical order of operations (PEMDAS/BODMAS):
+
+1. **P**arentheses/Brackets first
+2. **M**ultiplication and **D**ivision (left to right)
+3. **A**ddition and **S**ubtraction (left to right)
+
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "2 + 3 * 4"
+  }
+}
+```
+
+Returns `14` (not `20`) because multiplication is performed before addition.
+
+### Complex Expressions
+
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "((10 + 5) * 2 - 3) / 9"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "expression": "((10 + 5) * 2 - 3) / 9",
+  "result": 3
+}
+```
+
+### Decimal Numbers
+
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "3.14 * 2.5"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "expression": "3.14 * 2.5",
+  "result": 7.85
+}
+```
+
+### Unary Operators
+
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "-5 + 10"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "expression": "-5 + 10",
+  "result": 5
+}
+```
+
+## Parameters
+
+You must provide **either** `expression` or `expressions` parameter (not both).
+
+### expression (optional)
+- **Type**: string
+- **Description**: Single mathematical expression to evaluate
+- **Example**: `"2 + 3 * 4"`
+
+### expressions (optional)
+- **Type**: array of strings
+- **Description**: Multiple mathematical expressions to evaluate in one call
+- **Example**: `["2 + 3", "10 * 5", "(15 - 3) / 4"]`
+
+Each expression can contain:
+- Numbers (integers and decimals)  
+- Basic arithmetic operators (`+`, `-`, `*`, `/`, `%`)
+- Parentheses for grouping
+- Unary operators (`+`, `-`)
+- Whitespace (ignored)
+
+## Examples
+
+### Simple Arithmetic
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "25 / 5"
+  }
+}
+```
+
+### Percentage Calculations
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "150 * 0.20"
+  }
+}
+```
+
+### Complex Business Calculations
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "(1200 - 200) * 0.15 + 50"
+  }
+}
+```
+
+### Multiple Expressions (Array Mode)
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expressions": [
+      "2 + 3",
+      "10 * 5", 
+      "(15 - 3) / 4",
+      "2.5 + 1.5"
+    ]
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "expression": "2 + 3",
+      "result": 5
+    },
+    {
+      "expression": "10 * 5",
+      "result": 50
+    },
+    {
+      "expression": "(15 - 3) / 4",
+      "result": 3
+    },
+    {
+      "expression": "2.5 + 1.5",
+      "result": 4
+    }
+  ]
+}
+```
+
+### Batch Financial Calculations
+```json
+{
+  "name": "calculator", 
+  "arguments": {
+    "expressions": [
+      "1000 * 0.08",
+      "1500 * 0.15", 
+      "2000 * 0.12"
+    ]
+  }
+}
+```
+
+## Error Handling
+
+The calculator provides clear error messages for invalid expressions:
+
+### Division by Zero
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "10 / 0"
+  }
+}
+```
+**Error**: "division by zero"
+
+### Invalid Syntax
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "2 + * 3"
+  }
+}
+```
+**Error**: "unexpected character '*'"
+
+### Unmatched Parentheses
+```json
+{
+  "name": "calculator",
+  "arguments": {
+    "expression": "(2 + 3"
+  }
+}
+```
+**Error**: "expected closing parenthesis"
+
+## Limitations
+
+- No support for scientific notation (e.g., `1e6`)
+- No support for functions (e.g., `sqrt`, `sin`, `cos`)
+- No support for variables or constants (e.g., `π`, `e`)
+- No support for bitwise operations
+- Decimal precision limited by floating-point representation
+
+For advanced mathematical operations, consider implementing separate tools or using external mathematical libraries.

--- a/internal/imports/tools.go
+++ b/internal/imports/tools.go
@@ -4,6 +4,7 @@ import (
 	// Standard tools - always available
 	_ "github.com/sammcj/mcp-devtools/internal/tools/api"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/aws_documentation"
+	_ "github.com/sammcj/mcp-devtools/internal/tools/calculator"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/claudeagent"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/docprocessing"
 	_ "github.com/sammcj/mcp-devtools/internal/tools/filelength"

--- a/internal/tools/calculator/calculator.go
+++ b/internal/tools/calculator/calculator.go
@@ -1,0 +1,400 @@
+package calculator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"sync"
+	"unicode"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sammcj/mcp-devtools/internal/registry"
+	"github.com/sammcj/mcp-devtools/internal/tools"
+	"github.com/sirupsen/logrus"
+)
+
+// Calculator implements the tools.Tool interface for basic arithmetic calculations
+type Calculator struct{}
+
+// init registers the tool with the registry
+func init() {
+	registry.Register(&Calculator{})
+}
+
+// Definition returns the tool's definition for MCP registration
+func (c *Calculator) Definition() mcp.Tool {
+	return mcp.NewTool(
+		"calculator",
+		mcp.WithDescription("Calculator. Use when performing arithmetic to ensure accuracy. Supports +, -, *, /, %, parentheses, and decimal numbers."),
+		mcp.WithString("expression",
+			mcp.Description("Single mathematical expression to evaluate (e.g., '2 + 3 * 4', '(10 + 5) / 3', '12.5 * 2')"),
+		),
+		mcp.WithArray("expressions",
+			mcp.Description("Array of mathematical expressions to evaluate"),
+			mcp.Items(map[string]any{
+				"type": "string",
+			}),
+		),
+	)
+}
+
+// Execute executes the calculator's logic
+func (c *Calculator) Execute(ctx context.Context, logger *logrus.Logger, cache *sync.Map, args map[string]any) (*mcp.CallToolResult, error) {
+	logger.Info("Executing calculator")
+
+	// Check if we have a single expression or an array of expressions
+	if expressionRaw, ok := args["expression"]; ok {
+		// Single expression mode
+		expression, ok := expressionRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf("expression must be a string")
+		}
+
+		result, err := c.evaluateExpression(expression)
+		if err != nil {
+			return nil, err
+		}
+
+		response := map[string]any{
+			"expression": expression,
+			"result":     result,
+		}
+
+		return c.newToolResultJSON(response)
+
+	} else if expressionsRaw, ok := args["expressions"]; ok {
+		// Array mode
+		expressions, ok := expressionsRaw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("expressions must be an array")
+		}
+
+		if len(expressions) == 0 {
+			return nil, fmt.Errorf("expressions array cannot be empty")
+		}
+
+		results := make([]map[string]any, 0, len(expressions))
+
+		for i, exprRaw := range expressions {
+			expression, ok := exprRaw.(string)
+			if !ok {
+				return nil, fmt.Errorf("expression at index %d must be a string", i)
+			}
+
+			result, err := c.evaluateExpression(expression)
+			if err != nil {
+				return nil, fmt.Errorf("error in expression %d: %w", i, err)
+			}
+
+			results = append(results, map[string]any{
+				"expression": expression,
+				"result":     result,
+			})
+		}
+
+		response := map[string]any{
+			"results": results,
+		}
+
+		return c.newToolResultJSON(response)
+
+	} else {
+		return nil, fmt.Errorf("either 'expression' or 'expressions' parameter is required")
+	}
+}
+
+// evaluateExpression evaluates a single mathematical expression
+func (c *Calculator) evaluateExpression(expression string) (any, error) {
+	// Clean the expression
+	expression = strings.TrimSpace(expression)
+	if expression == "" {
+		return nil, fmt.Errorf("expression cannot be empty")
+	}
+
+	// Parse and evaluate the expression
+	parser := newParser(expression)
+	result, err := parser.parseExpression()
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate expression '%s': %w", expression, err)
+	}
+
+	// Check if we consumed all tokens
+	if !parser.isAtEnd() {
+		return nil, fmt.Errorf("unexpected characters after expression: %s", parser.remaining())
+	}
+
+	// Format result appropriately
+	if result == float64(int64(result)) {
+		// If it's a whole number, return as int
+		return int64(result), nil
+	} else {
+		return result, nil
+	}
+}
+
+// Parser represents an expression parser
+type parser struct {
+	expression string
+	position   int
+	current    rune
+}
+
+// newParser creates a new expression parser
+func newParser(expression string) *parser {
+	p := &parser{
+		expression: expression,
+		position:   0,
+	}
+	p.advance() // Initialize current character
+	return p
+}
+
+// advance moves to the next character
+func (p *parser) advance() {
+	if p.position >= len(p.expression) {
+		p.current = 0 // EOF
+		return
+	}
+	p.current = rune(p.expression[p.position])
+	p.position++
+}
+
+// isAtEnd checks if we're at the end of the expression
+func (p *parser) isAtEnd() bool {
+	return p.current == 0
+}
+
+// remaining returns the remaining unparsed part of the expression
+func (p *parser) remaining() string {
+	if p.position-1 >= len(p.expression) {
+		return ""
+	}
+	return p.expression[p.position-1:]
+}
+
+// skipWhitespace skips whitespace characters
+func (p *parser) skipWhitespace() {
+	for unicode.IsSpace(p.current) {
+		p.advance()
+	}
+}
+
+// parseNumber parses a number (integer or float)
+func (p *parser) parseNumber() (float64, error) {
+	start := p.position - 1
+
+	// Parse digits before decimal point
+	for unicode.IsDigit(p.current) {
+		p.advance()
+	}
+
+	// Handle decimal point
+	if p.current == '.' {
+		p.advance()
+		if !unicode.IsDigit(p.current) {
+			return 0, fmt.Errorf("expected digit after decimal point")
+		}
+		for unicode.IsDigit(p.current) {
+			p.advance()
+		}
+	}
+
+	end := p.position - 1
+	if p.current == 0 {
+		end = len(p.expression)
+	}
+
+	numStr := p.expression[start:end]
+	return strconv.ParseFloat(numStr, 64)
+}
+
+// parseExpression parses an expression (handles + and -)
+func (p *parser) parseExpression() (float64, error) {
+	left, err := p.parseTerm()
+	if err != nil {
+		return 0, err
+	}
+
+	for {
+		p.skipWhitespace()
+		switch p.current {
+		case '+':
+			p.advance()
+			right, err := p.parseTerm()
+			if err != nil {
+				return 0, err
+			}
+			left += right
+		case '-':
+			p.advance()
+			right, err := p.parseTerm()
+			if err != nil {
+				return 0, err
+			}
+			left -= right
+		default:
+			return left, nil
+		}
+	}
+}
+
+// parseTerm parses a term (handles *, /, %)
+func (p *parser) parseTerm() (float64, error) {
+	left, err := p.parseFactor()
+	if err != nil {
+		return 0, err
+	}
+
+	for {
+		p.skipWhitespace()
+		switch p.current {
+		case '*':
+			p.advance()
+			right, err := p.parseFactor()
+			if err != nil {
+				return 0, err
+			}
+			left *= right
+		case '/':
+			p.advance()
+			right, err := p.parseFactor()
+			if err != nil {
+				return 0, err
+			}
+			if right == 0 {
+				return 0, fmt.Errorf("division by zero")
+			}
+			left /= right
+		case '%':
+			p.advance()
+			right, err := p.parseFactor()
+			if err != nil {
+				return 0, err
+			}
+			if right == 0 {
+				return 0, fmt.Errorf("modulo by zero")
+			}
+			// Go's modulo operator behaviour for floats
+			left = float64(int64(left) % int64(right))
+		default:
+			return left, nil
+		}
+	}
+}
+
+// parseFactor parses a factor (handles numbers and parentheses)
+func (p *parser) parseFactor() (float64, error) {
+	p.skipWhitespace()
+
+	// Handle parentheses
+	if p.current == '(' {
+		p.advance()
+		result, err := p.parseExpression()
+		if err != nil {
+			return 0, err
+		}
+		p.skipWhitespace()
+		if p.current != ')' {
+			return 0, fmt.Errorf("expected closing parenthesis")
+		}
+		p.advance()
+		return result, nil
+	}
+
+	// Handle unary minus
+	if p.current == '-' {
+		p.advance()
+		factor, err := p.parseFactor()
+		if err != nil {
+			return 0, err
+		}
+		return -factor, nil
+	}
+
+	// Handle unary plus
+	if p.current == '+' {
+		p.advance()
+		return p.parseFactor()
+	}
+
+	// Handle numbers
+	if unicode.IsDigit(p.current) || p.current == '.' {
+		return p.parseNumber()
+	}
+
+	return 0, fmt.Errorf("unexpected character '%c'", p.current)
+}
+
+// newToolResultJSON creates a new tool result with JSON content
+func (c *Calculator) newToolResultJSON(data any) (*mcp.CallToolResult, error) {
+	jsonBytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal JSON: %w", err)
+	}
+
+	return mcp.NewToolResultText(string(jsonBytes)), nil
+}
+
+// ProvideExtendedInfo implements the ExtendedHelpProvider interface for the Calculator tool
+func (c *Calculator) ProvideExtendedInfo() *tools.ExtendedHelp {
+	return &tools.ExtendedHelp{
+		WhenToUse:    "Use when performing arithmetic calculations to ensure accuracy, when complex expressions need proper order of operations, when handling multiple related calculations in batch, or when decimal precision is important for financial calculations.",
+		WhenNotToUse: "Don't use for scientific functions (sqrt, sin, cos, log, etc.), bitwise operations or boolean logic, statistical calculations or data analysis, or advanced mathematical operations like matrices or calculus.",
+		CommonPatterns: []string{
+			"Basic arithmetic: \"2 + 3 * 4\" (follows order of operations)",
+			"Parentheses for grouping: \"(10 + 5) * 2\"",
+			"Decimal calculations: \"12.50 * 1.08\" (tax calculations)",
+			"Array mode for batch: {\"expressions\": [\"100 * 0.15\", \"200 * 0.15\"]}",
+			"Unary operators: \"-5 + 10\" or \"-(2 + 3)\"",
+			"Use parentheses to make complex expressions clear",
+			"Test complex calculations by breaking them into smaller parts",
+			"Be aware of precision limitations with decimal numbers",
+			"Handle errors gracefully when expressions might be invalid",
+			"Use array mode for batch calculations to improve efficiency",
+			"Group related calculations in arrays when performing multiple operations",
+		},
+		ParameterDetails: map[string]string{
+			"expression":  "Single mathematical expression to evaluate (string). Supports +, -, *, /, % operators with standard precedence, parentheses for grouping, and unary +/- operators.",
+			"expressions": "Array of mathematical expressions for batch processing (array of strings). Each expression follows same rules as single expression parameter.",
+		},
+		Examples: []tools.ToolExample{
+			{
+				Description:    "Basic percentage calculation",
+				Arguments:      map[string]any{"expression": "150 * 0.20"},
+				ExpectedResult: `{"expression": "150 * 0.20", "result": 30}`,
+			},
+			{
+				Description:    "Complex business calculation with proper order",
+				Arguments:      map[string]any{"expression": "(1200 - 200) * 0.15 + 50"},
+				ExpectedResult: `{"expression": "(1200 - 200) * 0.15 + 50", "result": 200}`,
+			},
+			{
+				Description: "Batch calculations for efficiency",
+				Arguments: map[string]any{
+					"expressions": []string{"2 + 3", "10 * 5", "(15 - 3) / 4"},
+				},
+				ExpectedResult: `{"results": [{"expression": "2 + 3", "result": 5}, {"expression": "10 * 5", "result": 50}, {"expression": "(15 - 3) / 4", "result": 3}]}`,
+			},
+		},
+		Troubleshooting: []tools.TroubleshootingTip{
+			{
+				Problem:  "Getting 'division by zero' error",
+				Solution: "Check expressions for division or modulo by zero (e.g., '5/0' or '5%0')",
+			},
+			{
+				Problem:  "Unexpected results with order of operations",
+				Solution: "Use parentheses to make precedence explicit: '2 + 3 * 4' = 14, but '(2 + 3) * 4' = 20",
+			},
+			{
+				Problem:  "Syntax errors with unexpected characters",
+				Solution: "Ensure only supported operators (+, -, *, /, %, parentheses) and valid decimal numbers",
+			},
+			{
+				Problem:  "Array mode returns error for single calculation",
+				Solution: "Use 'expression' parameter for single calculations, 'expressions' array for multiple",
+			},
+		},
+	}
+}

--- a/internal/tools/calculator/calculator.go
+++ b/internal/tools/calculator/calculator.go
@@ -343,9 +343,7 @@ func (c *Calculator) ProvideExtendedInfo() *tools.ExtendedHelp {
 		WhenToUse:    "Use when performing arithmetic calculations to ensure accuracy, when complex expressions need proper order of operations, when handling multiple related calculations in batch, or when decimal precision is important for financial calculations.",
 		WhenNotToUse: "Don't use for scientific functions (sqrt, sin, cos, log, etc.), bitwise operations or boolean logic, statistical calculations or data analysis, or advanced mathematical operations like matrices or calculus.",
 		CommonPatterns: []string{
-			"Basic arithmetic: \"2 + 3 * 4\" (follows order of operations)",
 			"Parentheses for grouping: \"(10 + 5) * 2\"",
-			"Decimal calculations: \"12.50 * 1.08\" (tax calculations)",
 			"Array mode for batch: {\"expressions\": [\"100 * 0.15\", \"200 * 0.15\"]}",
 			"Unary operators: \"-5 + 10\" or \"-(2 + 3)\"",
 			"Use parentheses to make complex expressions clear",

--- a/tests/tools/calculator_test.go
+++ b/tests/tools/calculator_test.go
@@ -1,0 +1,451 @@
+package tools_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sammcj/mcp-devtools/internal/tools/calculator"
+	"github.com/sammcj/mcp-devtools/tests/testutils"
+)
+
+// extractCalculatorResult extracts the result from calculator tool response
+func extractCalculatorResult(result *mcp.CallToolResult) (any, error) {
+	if len(result.Content) == 0 {
+		return nil, fmt.Errorf("no content in result")
+	}
+
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	if !ok {
+		return nil, fmt.Errorf("expected text content")
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal([]byte(textContent.Text), &response); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	return response["result"], nil
+}
+
+func TestCalculator_Definition(t *testing.T) {
+	tool := &calculator.Calculator{}
+	definition := tool.Definition()
+
+	// Test basic definition properties
+	testutils.AssertEqual(t, "calculator", definition.Name)
+	testutils.AssertNotNil(t, definition.Description)
+
+	// Test that description contains key phrases
+	desc := definition.Description
+	if !testutils.Contains(desc, "arithmetic") {
+		t.Errorf("Expected description to contain 'arithmetic', got: %s", desc)
+	}
+
+	// Test input schema exists
+	testutils.AssertNotNil(t, definition.InputSchema)
+}
+
+func TestCalculator_Execute_BasicArithmetic(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	tests := []struct {
+		expression string
+		expected   any
+	}{
+		{"2 + 3", float64(5)},
+		{"10 - 4", float64(6)},
+		{"6 * 7", float64(42)},
+		{"15 / 3", float64(5)},
+		{"17 % 5", float64(2)},
+		{"2.5 + 1.5", 4.0},
+		{"10.0 / 4.0", 2.5},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			args := map[string]any{
+				"expression": test.expression,
+			}
+
+			result, err := tool.Execute(ctx, logger, cache, args)
+
+			testutils.AssertNoError(t, err)
+			testutils.AssertNotNil(t, result)
+
+			// Extract result from JSON response
+			actualResult, err := extractCalculatorResult(result)
+			testutils.AssertNoError(t, err)
+			testutils.AssertEqual(t, test.expected, actualResult)
+		})
+	}
+}
+
+func TestCalculator_Execute_OrderOfOperations(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	tests := []struct {
+		expression string
+		expected   any
+	}{
+		{"2 + 3 * 4", float64(14)},     // Should be 2 + 12 = 14, not (2 + 3) * 4 = 20
+		{"20 - 2 * 5", float64(10)},    // Should be 20 - 10 = 10, not (20 - 2) * 5 = 90
+		{"2 * 3 + 4", float64(10)},     // Should be 6 + 4 = 10
+		{"15 / 3 + 2", float64(7)},     // Should be 5 + 2 = 7
+		{"2 + 3 * 4 - 1", float64(13)}, // Should be 2 + 12 - 1 = 13
+		{"8 / 2 / 2", float64(2)},      // Should be (8 / 2) / 2 = 2 (left-to-right)
+		{"2 * 3 * 4", float64(24)},     // Should be ((2 * 3) * 4) = 24
+	}
+
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			args := map[string]any{
+				"expression": test.expression,
+			}
+
+			result, err := tool.Execute(ctx, logger, cache, args)
+
+			testutils.AssertNoError(t, err)
+			testutils.AssertNotNil(t, result)
+
+			// Extract result from JSON response
+			actualResult, err := extractCalculatorResult(result)
+			testutils.AssertNoError(t, err)
+			testutils.AssertEqual(t, test.expected, actualResult)
+		})
+	}
+}
+
+func TestCalculator_Execute_Parentheses(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	tests := []struct {
+		expression string
+		expected   any
+	}{
+		{"(2 + 3) * 4", float64(20)},       // Should be 5 * 4 = 20
+		{"2 * (3 + 4)", float64(14)},       // Should be 2 * 7 = 14
+		{"(10 + 5) / 3", float64(5)},       // Should be 15 / 3 = 5
+		{"((2 + 3) * 4)", float64(20)},     // Nested parentheses
+		{"2 * (3 + 4) - 1", float64(13)},   // Should be 2 * 7 - 1 = 13
+		{"(2 + 3) * (4 - 1)", float64(15)}, // Should be 5 * 3 = 15
+	}
+
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			args := map[string]any{
+				"expression": test.expression,
+			}
+
+			result, err := tool.Execute(ctx, logger, cache, args)
+
+			testutils.AssertNoError(t, err)
+			testutils.AssertNotNil(t, result)
+
+			// Extract result from JSON response
+			actualResult, err := extractCalculatorResult(result)
+			testutils.AssertNoError(t, err)
+			testutils.AssertEqual(t, test.expected, actualResult)
+		})
+	}
+}
+
+func TestCalculator_Execute_UnaryOperators(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	tests := []struct {
+		expression string
+		expected   any
+	}{
+		{"-5", float64(-5)},
+		{"+5", float64(5)},
+		{"-5 + 3", float64(-2)},
+		{"-(2 + 3)", float64(-5)},
+		{"-(2 * 3) + 10", float64(4)},
+		{"5 + (-3)", float64(2)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			args := map[string]any{
+				"expression": test.expression,
+			}
+
+			result, err := tool.Execute(ctx, logger, cache, args)
+
+			testutils.AssertNoError(t, err)
+			testutils.AssertNotNil(t, result)
+
+			// Extract result from JSON response
+			actualResult, err := extractCalculatorResult(result)
+			testutils.AssertNoError(t, err)
+			testutils.AssertEqual(t, test.expected, actualResult)
+		})
+	}
+}
+
+func TestCalculator_Execute_ErrorHandling(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	tests := []struct {
+		expression  string
+		expectedErr string
+	}{
+		{"", "expression cannot be empty"},
+		{"5 / 0", "division by zero"},
+		{"5 % 0", "modulo by zero"},
+		{"2 +", "unexpected character"},
+		{"2 + * 3", "unexpected character"},
+		{"(2 + 3", "expected closing parenthesis"},
+		{"2 + 3)", "unexpected characters after expression"},
+		{"2 ** 3", "unexpected character '*'"},
+		{"2 + abc", "unexpected character 'a'"},
+		{"2.5.5", "unexpected characters after expression"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			args := map[string]any{
+				"expression": test.expression,
+			}
+
+			_, err := tool.Execute(ctx, logger, cache, args)
+
+			testutils.AssertError(t, err)
+			testutils.AssertErrorContains(t, err, test.expectedErr)
+		})
+	}
+}
+
+func TestCalculator_Execute_WhitespaceHandling(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	tests := []struct {
+		expression string
+		expected   any
+	}{
+		{" 2 + 3 ", float64(5)},
+		{"2+3", float64(5)},
+		{" ( 2 + 3 ) * 4 ", float64(20)},
+		{"2  *  3", float64(6)},
+		{"\t2\n+\r3\t", float64(5)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			args := map[string]any{
+				"expression": test.expression,
+			}
+
+			result, err := tool.Execute(ctx, logger, cache, args)
+
+			testutils.AssertNoError(t, err)
+			testutils.AssertNotNil(t, result)
+
+			// Extract result from JSON response
+			actualResult, err := extractCalculatorResult(result)
+			testutils.AssertNoError(t, err)
+			testutils.AssertEqual(t, test.expected, actualResult)
+		})
+	}
+}
+
+func TestCalculator_Execute_MissingParameter(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{}
+
+	_, err := tool.Execute(ctx, logger, cache, args)
+
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "either 'expression' or 'expressions' parameter is required")
+}
+
+func TestCalculator_Execute_InvalidParameterType(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{
+		"expression": 123, // Invalid type
+	}
+
+	_, err := tool.Execute(ctx, logger, cache, args)
+
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "expression must be a string")
+}
+
+func TestCalculator_Execute_ArrayMode(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	// Test array of expressions
+	args := map[string]any{
+		"expressions": []any{
+			"2 + 3",
+			"10 * 5",
+			"(15 - 3) / 4",
+			"2.5 + 1.5",
+		},
+	}
+
+	result, err := tool.Execute(ctx, logger, cache, args)
+	testutils.AssertNoError(t, err)
+	testutils.AssertNotNil(t, result)
+
+	// Extract results from JSON response
+	textContent, ok := mcp.AsTextContent(result.Content[0])
+	testutils.AssertNotNil(t, textContent)
+	if !ok {
+		t.Fatal("Expected text content")
+	}
+
+	var response map[string]any
+	err = json.Unmarshal([]byte(textContent.Text), &response)
+	testutils.AssertNoError(t, err)
+
+	results, ok := response["results"].([]any)
+	if !ok {
+		t.Fatal("Expected results array")
+	}
+
+	testutils.AssertEqual(t, 4, len(results))
+
+	// Check each result
+	expectedResults := []float64{5, 50, 3, 4}
+	for i, expectedResult := range expectedResults {
+		resultItem, ok := results[i].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected result %d to be a map", i)
+		}
+
+		actualResult := resultItem["result"]
+		testutils.AssertEqual(t, expectedResult, actualResult)
+	}
+}
+
+func TestCalculator_Execute_ArrayMode_EmptyArray(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{
+		"expressions": []any{},
+	}
+
+	_, err := tool.Execute(ctx, logger, cache, args)
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "expressions array cannot be empty")
+}
+
+func TestCalculator_Execute_ArrayMode_InvalidType(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{
+		"expressions": []any{
+			"2 + 3",
+			123, // Invalid type
+		},
+	}
+
+	_, err := tool.Execute(ctx, logger, cache, args)
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "expression at index 1 must be a string")
+}
+
+func TestCalculator_Execute_ArrayMode_WithError(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{
+		"expressions": []any{
+			"2 + 3",
+			"5 / 0", // This will cause an error
+		},
+	}
+
+	_, err := tool.Execute(ctx, logger, cache, args)
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "error in expression 1")
+	testutils.AssertErrorContains(t, err, "division by zero")
+}
+
+func TestCalculator_Execute_NoParameters(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	args := map[string]any{}
+
+	_, err := tool.Execute(ctx, logger, cache, args)
+	testutils.AssertError(t, err)
+	testutils.AssertErrorContains(t, err, "either 'expression' or 'expressions' parameter is required")
+}
+
+func TestCalculator_Execute_ComplexExpressions(t *testing.T) {
+	tool := &calculator.Calculator{}
+	logger := testutils.CreateTestLogger()
+	cache := testutils.CreateTestCache()
+	ctx := testutils.CreateTestContext()
+
+	tests := []struct {
+		expression string
+		expected   any
+	}{
+		{"((2 + 3) * 4 - 1) / (5 + 2)", float64(19.0 / 7.0)}, // (20 - 1) / 7 = 19/7 ≈ 2.714...
+		{"2 + 3 * 4 - 5 / 2 + 1", float64(12.5)},             // 2 + 12 - 2.5 + 1 = 12.5
+		{"-((2 + 3) * 4)", float64(-20)},                     // -(5 * 4) = -20
+		{"5 * -3 + 10", float64(-5)},                         // -15 + 10 = -5
+	}
+
+	for _, test := range tests {
+		t.Run(test.expression, func(t *testing.T) {
+			args := map[string]any{
+				"expression": test.expression,
+			}
+
+			result, err := tool.Execute(ctx, logger, cache, args)
+
+			testutils.AssertNoError(t, err)
+			testutils.AssertNotNil(t, result)
+
+			// Extract result from JSON response
+			actualResult, err := extractCalculatorResult(result)
+			testutils.AssertNoError(t, err)
+			testutils.AssertEqual(t, test.expected, actualResult)
+		})
+	}
+}


### PR DESCRIPTION
- Feature: New tool - `calculator` a basic calculator, because LLMs are bad at maths.

```plain
> I've enabled you with a new 'calculator' tool I've created, can you try it out to make sure it working properly?

⏺ dev-tools - calculator (MCP)(expression: "15 + 27 * 3")
  ⎿  {
       "expression": "15 + 27 * 3",
       "result": 96
     … +1 line (ctrl+r to expand)

⏺ The calculator tool is working correctly. It properly evaluated 15 + 27 * 3 = 96 following the correct order of operations (multiplication before addition).

⏺ dev-tools - calculator (MCP)(expressions: ["(10 + 5) / 3","12.5 * 2","100 % 7"])
  ⎿  {
       "results": [
         {
     … +13 lines (ctrl+r to expand)

⏺ The batch calculation feature also works properly. It correctly calculated:
  - (10 + 5) / 3 = 5
  - 12.5 * 2 = 25
  - 100 % 7 = 2 (modulo operation)
```