### PR TITLE
chore: add optional windows builds

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -388,7 +388,7 @@ jobs:
           fi
 
           # Make binaries executable
-          find release -type f ! -name '*.exe' -exec chmod +x {} \;
+          chmod +x release/*
 
           # List what we have
           ls -la release/


### PR DESCRIPTION
- chore: add optional windows builds when manually running build/release workflow