### PR TITLE
chore: optimise token usage with search and fetch

### DIFF
--- a/internal/tools/internetsearch/brave/provider.go
+++ b/internal/tools/internetsearch/brave/provider.go
@@ -101,7 +101,7 @@ func (p *BraveProvider) executeInternetSearch(ctx context.Context, logger *logru
 
 	// Convert to unified format
 	if response.Web == nil || len(response.Web.Results) == 0 {
-		return p.createEmptyResponse(query)
+		return p.createEmptyResponse()
 	}
 
 	results := make([]internetsearch.SearchResult, 0, len(response.Web.Results))
@@ -115,7 +115,6 @@ func (p *BraveProvider) executeInternetSearch(ctx context.Context, logger *logru
 			Title:       decodeHTMLEntities(webResult.Title),
 			URL:         webResult.URL,
 			Description: decodeHTMLEntities(webResult.Description),
-			Type:        "web",
 			Metadata:    metadata,
 		})
 	}
@@ -143,7 +142,7 @@ func (p *BraveProvider) executeImageSearch(ctx context.Context, logger *logrus.L
 
 	// Convert to unified format
 	if len(response.Results) == 0 {
-		return p.createEmptyResponse(query)
+		return p.createEmptyResponse()
 	}
 
 	results := make([]internetsearch.SearchResult, 0, len(response.Results))
@@ -164,7 +163,6 @@ func (p *BraveProvider) executeImageSearch(ctx context.Context, logger *logrus.L
 			Title:       decodeHTMLEntities(imageResult.Title),
 			URL:         imageResult.URL,
 			Description: fmt.Sprintf("Image: %s", decodeHTMLEntities(imageResult.Title)),
-			Type:        "image",
 			Metadata:    metadata,
 		})
 	}
@@ -197,7 +195,7 @@ func (p *BraveProvider) executeNewsSearch(ctx context.Context, logger *logrus.Lo
 
 	// Convert to unified format
 	if len(response.Results) == 0 {
-		return p.createEmptyResponse(query)
+		return p.createEmptyResponse()
 	}
 
 	results := make([]internetsearch.SearchResult, 0, len(response.Results))
@@ -211,7 +209,6 @@ func (p *BraveProvider) executeNewsSearch(ctx context.Context, logger *logrus.Lo
 			Title:       decodeHTMLEntities(newsResult.Title),
 			URL:         newsResult.URL,
 			Description: decodeHTMLEntities(newsResult.Description),
-			Type:        "news",
 			Metadata:    metadata,
 		})
 	}
@@ -244,7 +241,7 @@ func (p *BraveProvider) executeVideoSearch(ctx context.Context, logger *logrus.L
 
 	// Convert to unified format
 	if len(response.Results) == 0 {
-		return p.createEmptyResponse(query)
+		return p.createEmptyResponse()
 	}
 
 	results := make([]internetsearch.SearchResult, 0, len(response.Results))
@@ -264,7 +261,6 @@ func (p *BraveProvider) executeVideoSearch(ctx context.Context, logger *logrus.L
 			Title:       decodeHTMLEntities(videoResult.Title),
 			URL:         videoResult.URL,
 			Description: fmt.Sprintf("Video: %s", decodeHTMLEntities(videoResult.Title)),
-			Type:        "video",
 			Metadata:    metadata,
 		})
 	}
@@ -303,7 +299,7 @@ func (p *BraveProvider) executeLocalSearch(ctx context.Context, logger *logrus.L
 	}
 
 	if webResponse.Web == nil || len(webResponse.Web.Results) == 0 {
-		return p.createEmptyResponse(query)
+		return p.createEmptyResponse()
 	}
 
 	// Convert web results with fallback indicator
@@ -319,7 +315,6 @@ func (p *BraveProvider) executeLocalSearch(ctx context.Context, logger *logrus.L
 			Title:       decodeHTMLEntities(webResult.Title),
 			URL:         webResult.URL,
 			Description: decodeHTMLEntities(webResult.Description),
-			Type:        "web",
 			Metadata:    metadata,
 		})
 	}
@@ -431,7 +426,6 @@ func (p *BraveProvider) processLocalResults(ctx context.Context, logger *logrus.
 			Title:       decodeHTMLEntities(location.Title),
 			URL:         location.URL,
 			Description: decodeHTMLEntities(description),
-			Type:        "local",
 			Metadata:    metadata,
 		})
 	}
@@ -440,24 +434,20 @@ func (p *BraveProvider) processLocalResults(ctx context.Context, logger *logrus.
 }
 
 // Helper functions
-func (p *BraveProvider) createEmptyResponse(query string) (*internetsearch.SearchResponse, error) {
+func (p *BraveProvider) createEmptyResponse() (*internetsearch.SearchResponse, error) {
 	result := &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: 0,
-		Results:     []internetsearch.SearchResult{},
-		Provider:    "brave",
-		Timestamp:   time.Now(),
+		Results:   []internetsearch.SearchResult{},
+		Provider:  "brave",
+		Timestamp: time.Now(),
 	}
 	return result, nil
 }
 
 func (p *BraveProvider) createSuccessResponse(query string, results []internetsearch.SearchResult, logger *logrus.Logger) (*internetsearch.SearchResponse, error) {
 	result := &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: len(results),
-		Results:     results,
-		Provider:    "brave",
-		Timestamp:   time.Now(),
+		Results:   results,
+		Provider:  "brave",
+		Timestamp: time.Now(),
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/internal/tools/internetsearch/duckduckgo/provider.go
+++ b/internal/tools/internetsearch/duckduckgo/provider.go
@@ -201,13 +201,12 @@ func (p *DuckDuckGoProvider) executeInternetSearch(ctx context.Context, logger *
 			Title:       p.cleanText(title),
 			URL:         link,
 			Description: p.cleanText(snippet),
-			Type:        "web",
 			Metadata:    metadata,
 		})
 	})
 
 	if len(results) == 0 {
-		return p.createEmptyResponse(query), nil
+		return p.createEmptyResponse(), nil
 	}
 
 	return p.createSuccessResponse(query, results, logger), nil
@@ -222,23 +221,19 @@ func (p *DuckDuckGoProvider) cleanText(text string) string {
 }
 
 // Helper functions
-func (p *DuckDuckGoProvider) createEmptyResponse(query string) *internetsearch.SearchResponse {
+func (p *DuckDuckGoProvider) createEmptyResponse() *internetsearch.SearchResponse {
 	return &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: 0,
-		Results:     []internetsearch.SearchResult{},
-		Provider:    "duckduckgo",
-		Timestamp:   time.Now(),
+		Results:   []internetsearch.SearchResult{},
+		Provider:  "duckduckgo",
+		Timestamp: time.Now(),
 	}
 }
 
 func (p *DuckDuckGoProvider) createSuccessResponse(query string, results []internetsearch.SearchResult, logger *logrus.Logger) *internetsearch.SearchResponse {
 	result := &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: len(results),
-		Results:     results,
-		Provider:    "duckduckgo",
-		Timestamp:   time.Now(),
+		Results:   results,
+		Provider:  "duckduckgo",
+		Timestamp: time.Now(),
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/internal/tools/internetsearch/google/provider.go
+++ b/internal/tools/internetsearch/google/provider.go
@@ -123,7 +123,7 @@ func (p *GoogleProvider) executeInternetSearch(ctx context.Context, logger *logr
 
 	// Convert to unified format
 	if len(response.Items) == 0 {
-		return p.createEmptyResponse(query)
+		return p.createEmptyResponse()
 	}
 
 	results := make([]internetsearch.SearchResult, 0, len(response.Items))
@@ -137,7 +137,6 @@ func (p *GoogleProvider) executeInternetSearch(ctx context.Context, logger *logr
 			Title:       item.Title,
 			URL:         item.Link,
 			Description: item.Snippet,
-			Type:        "web",
 			Metadata:    metadata,
 		})
 	}
@@ -176,7 +175,7 @@ func (p *GoogleProvider) executeImageSearch(ctx context.Context, logger *logrus.
 
 	// Convert to unified format
 	if len(response.Items) == 0 {
-		return p.createEmptyResponse(query)
+		return p.createEmptyResponse()
 	}
 
 	results := make([]internetsearch.SearchResult, 0, len(response.Items))
@@ -209,7 +208,6 @@ func (p *GoogleProvider) executeImageSearch(ctx context.Context, logger *logrus.
 			Title:       item.Title,
 			URL:         item.Link,
 			Description: description,
-			Type:        "image",
 			Metadata:    metadata,
 		})
 	}
@@ -218,24 +216,20 @@ func (p *GoogleProvider) executeImageSearch(ctx context.Context, logger *logrus.
 }
 
 // Helper functions
-func (p *GoogleProvider) createEmptyResponse(query string) (*internetsearch.SearchResponse, error) {
+func (p *GoogleProvider) createEmptyResponse() (*internetsearch.SearchResponse, error) {
 	result := &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: 0,
-		Results:     []internetsearch.SearchResult{},
-		Provider:    "google",
-		Timestamp:   time.Now(),
+		Results:   []internetsearch.SearchResult{},
+		Provider:  "google",
+		Timestamp: time.Now(),
 	}
 	return result, nil
 }
 
 func (p *GoogleProvider) createSuccessResponse(query string, results []internetsearch.SearchResult, logger *logrus.Logger) (*internetsearch.SearchResponse, error) {
 	result := &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: len(results),
-		Results:     results,
-		Provider:    "google",
-		Timestamp:   time.Now(),
+		Results:   results,
+		Provider:  "google",
+		Timestamp: time.Now(),
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/internal/tools/internetsearch/searxng/provider.go
+++ b/internal/tools/internetsearch/searxng/provider.go
@@ -225,7 +225,7 @@ func (p *SearXNGProvider) executeSearch(ctx context.Context, logger *logrus.Logg
 
 	// Convert to unified format
 	if len(searxngResp.Results) == 0 {
-		return p.createEmptyResponse(query), nil
+		return p.createEmptyResponse(), nil
 	}
 
 	results := make([]internetsearch.SearchResult, 0, len(searxngResp.Results))
@@ -243,7 +243,6 @@ func (p *SearXNGProvider) executeSearch(ctx context.Context, logger *logrus.Logg
 			Title:       searxngResult.Title,
 			URL:         searxngResult.URL,
 			Description: searxngResult.Content,
-			Type:        searchType,
 			Metadata:    metadata,
 		})
 	}
@@ -252,23 +251,19 @@ func (p *SearXNGProvider) executeSearch(ctx context.Context, logger *logrus.Logg
 }
 
 // Helper functions
-func (p *SearXNGProvider) createEmptyResponse(query string) *internetsearch.SearchResponse {
+func (p *SearXNGProvider) createEmptyResponse() *internetsearch.SearchResponse {
 	return &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: 0,
-		Results:     []internetsearch.SearchResult{},
-		Provider:    "searxng",
-		Timestamp:   time.Now(),
+		Results:   []internetsearch.SearchResult{},
+		Provider:  "searxng",
+		Timestamp: time.Now(),
 	}
 }
 
 func (p *SearXNGProvider) createSuccessResponse(query string, results []internetsearch.SearchResult, logger *logrus.Logger) *internetsearch.SearchResponse {
 	result := &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: len(results),
-		Results:     results,
-		Provider:    "searxng",
-		Timestamp:   time.Now(),
+		Results:   results,
+		Provider:  "searxng",
+		Timestamp: time.Now(),
 	}
 
 	logger.WithFields(logrus.Fields{

--- a/internal/tools/internetsearch/types.go
+++ b/internal/tools/internetsearch/types.go
@@ -9,15 +9,12 @@ type SearchResult struct {
 	Title       string         `json:"title"`
 	URL         string         `json:"url"`
 	Description string         `json:"description"`
-	Type        string         `json:"type"` // web, image, news, video, local
 	Metadata    map[string]any `json:"metadata,omitempty"`
 }
 
 // SearchResponse represents a unified response structure
 type SearchResponse struct {
-	Query       string         `json:"query"`
-	ResultCount int            `json:"resultCount"`
-	Results     []SearchResult `json:"results"`
-	Provider    string         `json:"provider"`
-	Timestamp   time.Time      `json:"timestamp"`
+	Results   []SearchResult `json:"results"`
+	Provider  string         `json:"provider"`
+	Timestamp time.Time      `json:"timestamp"`
 }

--- a/internal/tools/internetsearch/unified/internet_search.go
+++ b/internal/tools/internetsearch/unified/internet_search.go
@@ -172,7 +172,7 @@ After you have received the results you can fetch the url if you want to read th
 		),
 		mcp.WithNumber("count",
 			mcp.Description("Number of results (limits vary by provider & type)"),
-			mcp.DefaultNumber(4),
+			mcp.DefaultNumber(5),
 		),
 	}
 

--- a/internal/tools/internetsearch/unified/unified_test.go
+++ b/internal/tools/internetsearch/unified/unified_test.go
@@ -31,19 +31,15 @@ func (m *mockProvider) Search(ctx context.Context, logger *logrus.Logger, search
 		return nil, fmt.Errorf("mock provider %s failed", m.name)
 	}
 
-	query, ok := args["query"].(string)
-	if !ok {
+	if _, ok := args["query"].(string); !ok {
 		return nil, fmt.Errorf("mockProvider: expected 'query' argument of type string, got %T", args["query"])
 	}
 	return &internetsearch.SearchResponse{
-		Query:       query,
-		ResultCount: 1,
 		Results: []internetsearch.SearchResult{
 			{
 				Title:       fmt.Sprintf("Result from %s", m.name),
 				URL:         "https://example.com",
 				Description: fmt.Sprintf("Mock result from %s", m.name),
-				Type:        searchType,
 			},
 		},
 		Provider: m.name,

--- a/internal/tools/webfetch/client.go
+++ b/internal/tools/webfetch/client.go
@@ -142,7 +142,6 @@ func (c *WebClient) FetchContent(ctx context.Context, logger *logrus.Logger, tar
 	// Check for HTTP errors
 	if resp.StatusCode >= 400 {
 		return &FetchURLResponse{
-			URL:              targetURL,
 			ContentType:      resp.Header.Get("Content-Type"),
 			StatusCode:       resp.StatusCode,
 			Content:          "",
@@ -199,7 +198,6 @@ func (c *WebClient) FetchContent(ctx context.Context, logger *logrus.Logger, tar
 	}).Debug("Successfully fetched content")
 
 	response := &FetchURLResponse{
-		URL:              targetURL,
 		Content:          string(body),
 		Truncated:        false, // Will be set later during pagination
 		StartIndex:       0,

--- a/internal/tools/webfetch/fetch_url.go
+++ b/internal/tools/webfetch/fetch_url.go
@@ -98,7 +98,6 @@ func (t *FetchURLTool) Execute(ctx context.Context, logger *logrus.Logger, cache
 
 	// Convert SafeHTTPResponse to FetchURLResponse format
 	response := &FetchURLResponse{
-		URL:         request.URL,
 		Content:     string(safeResp.Content),
 		ContentType: safeResp.ContentType,
 		StatusCode:  safeResp.StatusCode,
@@ -129,7 +128,6 @@ func (t *FetchURLTool) Execute(ctx context.Context, logger *logrus.Logger, cache
 	if securityNotice != "" {
 		// Convert response to map for adding security field
 		responseMap := map[string]any{
-			"url":             paginatedResponse.URL,
 			"content":         paginatedResponse.Content,
 			"truncated":       paginatedResponse.Truncated,
 			"start_index":     paginatedResponse.StartIndex,
@@ -246,7 +244,6 @@ func (t *FetchURLTool) applyPagination(originalResponse *FetchURLResponse, proce
 	// Check if start_index is beyond content length
 	if request.StartIndex >= totalLength {
 		return &FetchURLResponse{
-			URL:            originalResponse.URL,
 			Content:        "",
 			Truncated:      false,
 			StartIndex:     request.StartIndex,
@@ -313,7 +310,6 @@ func (t *FetchURLTool) applyPagination(originalResponse *FetchURLResponse, proce
 
 	// Create enhanced response
 	response := &FetchURLResponse{
-		URL:              originalResponse.URL,
 		Content:          content,
 		Truncated:        truncated,
 		StartIndex:       request.StartIndex,

--- a/internal/tools/webfetch/types.go
+++ b/internal/tools/webfetch/types.go
@@ -10,7 +10,6 @@ type FetchURLRequest struct {
 
 // FetchURLResponse represents the response from the fetch-url tool
 type FetchURLResponse struct {
-	URL              string `json:"url"`
 	ContentType      string `json:"content_type,omitempty"`
 	StatusCode       int    `json:"status_code,omitempty"`
 	Content          string `json:"content"`

--- a/tests/tools/webfetch_test.go
+++ b/tests/tools/webfetch_test.go
@@ -223,7 +223,6 @@ func TestProcessContent(t *testing.T) {
 		{
 			name: "HTML content conversion to markdown",
 			response: &webfetch.FetchURLResponse{
-				URL:         "https://example.com",
 				ContentType: "text/html",
 				StatusCode:  200,
 				Content:     "<html><body><h1>Title</h1><p>Content</p></body></html>",
@@ -235,7 +234,6 @@ func TestProcessContent(t *testing.T) {
 		{
 			name: "Raw HTML content",
 			response: &webfetch.FetchURLResponse{
-				URL:         "https://example.com",
 				ContentType: "text/html",
 				StatusCode:  200,
 				Content:     "<html><body><h1>Title</h1><p>Content</p></body></html>",
@@ -247,7 +245,6 @@ func TestProcessContent(t *testing.T) {
 		{
 			name: "Plain text content",
 			response: &webfetch.FetchURLResponse{
-				URL:         "https://example.com",
 				ContentType: "text/plain",
 				StatusCode:  200,
 				Content:     "This is plain text content.",
@@ -259,7 +256,6 @@ func TestProcessContent(t *testing.T) {
 		{
 			name: "Binary content",
 			response: &webfetch.FetchURLResponse{
-				URL:         "https://example.com",
 				ContentType: "application/octet-stream",
 				StatusCode:  200,
 				Content:     string([]byte{0x89, 0x50, 0x4E, 0x47}), // PNG header
@@ -271,7 +267,6 @@ func TestProcessContent(t *testing.T) {
 		{
 			name: "HTTP error response",
 			response: &webfetch.FetchURLResponse{
-				URL:         "https://example.com",
 				ContentType: "text/html",
 				StatusCode:  404,
 				Content:     "Not Found",
@@ -283,7 +278,6 @@ func TestProcessContent(t *testing.T) {
 		{
 			name: "Empty content",
 			response: &webfetch.FetchURLResponse{
-				URL:         "https://example.com",
 				ContentType: "text/html",
 				StatusCode:  200,
 				Content:     "",


### PR DESCRIPTION
- chore: optimise token usage with search and fetch by returning less useless information

---

This pull request refactors the internet search tools and related code to simplify the data structures used in search results and responses, and to standardise the handling of empty responses across multiple providers. The main changes include removing the `Type`, `Query`, and `ResultCount` fields from search result and response types, updating all providers to use the new simplified structures, and making minor adjustments to default parameters and test mocks. Additionally, some fields are removed from the web fetch response structures for consistency.

**Refactoring of search result and response structures:**

* Removed the `Type` field from the `SearchResult` struct and the `Query` and `ResultCount` fields from the `SearchResponse` struct in `types.go`. All code using these structs has been updated to reflect these changes.
* Updated all search providers (`BraveProvider`, `DuckDuckGoProvider`, `GoogleProvider`, `SearXNGProvider`) to remove usage of the `Type`, `Query`, and `ResultCount` fields in both their empty and success response methods, and in the construction of individual search results. [[1]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L104-R104) [[2]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L118) [[3]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L146-R145) [[4]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L167) [[5]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L200-R198) [[6]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L214) [[7]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L247-R244) [[8]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L267) [[9]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L306-R302) [[10]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L322) [[11]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L434) [[12]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L443-L446) [[13]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L456-L457) [[14]](diffhunk://#diff-695dc8d8e351ba5fb5ffa0067b3a7423da0a3bf4488ea00b4c50c7fccf2e4351L204-R209) [[15]](diffhunk://#diff-695dc8d8e351ba5fb5ffa0067b3a7423da0a3bf4488ea00b4c50c7fccf2e4351L225-L228) [[16]](diffhunk://#diff-695dc8d8e351ba5fb5ffa0067b3a7423da0a3bf4488ea00b4c50c7fccf2e4351L237-L238) [[17]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL126-R126) [[18]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL140) [[19]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL179-R178) [[20]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL212) [[21]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL221-L224) [[22]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL234-L235) [[23]](diffhunk://#diff-8bd006212b11c79dccee0d1f4a7f084cf742b74b6b25fc2b5a59bcc90c7f86f9L228-R228) [[24]](diffhunk://#diff-8bd006212b11c79dccee0d1f4a7f084cf742b74b6b25fc2b5a59bcc90c7f86f9L246) [[25]](diffhunk://#diff-8bd006212b11c79dccee0d1f4a7f084cf742b74b6b25fc2b5a59bcc90c7f86f9L255-L258) [[26]](diffhunk://#diff-8bd006212b11c79dccee0d1f4a7f084cf742b74b6b25fc2b5a59bcc90c7f86f9L267-L268)

**Standardization and simplification:**

* All `createEmptyResponse` and `createSuccessResponse` methods in search providers have been updated to remove the `query` parameter and the related fields in the response, further simplifying the response structure. [[1]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L443-L446) [[2]](diffhunk://#diff-3e0812371a04205f8dd2462888151eba7928659247cacd126a06dc6d3eaf7b73L456-L457) [[3]](diffhunk://#diff-695dc8d8e351ba5fb5ffa0067b3a7423da0a3bf4488ea00b4c50c7fccf2e4351L225-L228) [[4]](diffhunk://#diff-695dc8d8e351ba5fb5ffa0067b3a7423da0a3bf4488ea00b4c50c7fccf2e4351L237-L238) [[5]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL221-L224) [[6]](diffhunk://#diff-09496bc2d9390ee14f6ef6c5472169dde87c39f79de555acd815cd795ee7a4cfL234-L235) [[7]](diffhunk://#diff-8bd006212b11c79dccee0d1f4a7f084cf742b74b6b25fc2b5a59bcc90c7f86f9L255-L258) [[8]](diffhunk://#diff-8bd006212b11c79dccee0d1f4a7f084cf742b74b6b25fc2b5a59bcc90c7f86f9L267-L268)
* Test mocks and usage in `unified_test.go` have been updated to remove references to the removed fields.

**Other changes:**

* Increased the default number of search results returned by the unified internet search tool from 4 to 5.
* Removed the `URL` field from the `FetchURLResponse` struct and all related usages in the web fetch client and tool, further streamlining the response format. [[1]](diffhunk://#diff-a4f4f7cd022ee799b699d961900587ab0d3dbc0b7a50bec4e2be989161d484dfL145) [[2]](diffhunk://#diff-a4f4f7cd022ee799b699d961900587ab0d3dbc0b7a50bec4e2be989161d484dfL202) [[3]](diffhunk://#diff-2385612276e35398b9ffdca4c07106faa5557614be8f0d4c385f0ce16a262d62L101) [[4]](diffhunk://#diff-2385612276e35398b9ffdca4c07106faa5557614be8f0d4c385f0ce16a262d62L132) [[5]](diffhunk://#diff-2385612276e35398b9ffdca4c07106faa5557614be8f0d4c385f0ce16a262d62L249)