### PR TITLE
[fix]: Ensure kiro-agent is disabled by default

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -89,7 +89,7 @@ func requiresEnablement(toolName string) bool {
 		"codex-agent",
 		"copilot-agent",
 		"gemini-agent",
-		"q-developer-agent",
+		"kiro-agent",
 		"generate_changelog",
 		"process_document",
 		"pdf",

--- a/tests/tools/tool_enablement_test.go
+++ b/tests/tools/tool_enablement_test.go
@@ -113,7 +113,7 @@ func TestTools_DisabledByDefault_DynamicCheck(t *testing.T) {
 			"codex-agent",
 			"copilot-agent",
 			"gemini-agent",
-			"q-developer-agent",
+			"kiro-agent",
 		}
 
 		for _, agentName := range agentToolsThatMustRequireEnablement {

--- a/tests/unit/enablement_test.go
+++ b/tests/unit/enablement_test.go
@@ -125,14 +125,14 @@ func TestIsToolEnabled_AllSupportedTools(t *testing.T) {
 	supportedTools := []string{
 		"claude-agent",
 		"gemini-agent",
-		"q-developer-agent",
+		"kiro-agent",
 		"filesystem",
 		"vulnerability_scan",
 		"vulnerability-scan", // Normalised version
 		"sbom",
 	}
 
-	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "claude-agent,gemini-agent,q-developer-agent,filesystem,vulnerability_scan,sbom")
+	_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "claude-agent,gemini-agent,kiro-agent,filesystem,vulnerability_scan,sbom")
 	defer func() { _ = os.Unsetenv("ENABLE_ADDITIONAL_TOOLS") }()
 
 	for _, toolName := range supportedTools {

--- a/tests/unit/registry_test.go
+++ b/tests/unit/registry_test.go
@@ -335,37 +335,37 @@ func TestRegistry_ShouldRegisterTool(t *testing.T) {
 		registry.Init(logger)
 
 		// Test a tool that requires enablement but is not enabled
-		result := registry.ShouldRegisterTool("q-developer-agent")
+		result := registry.ShouldRegisterTool("kiro-agent")
 		testutils.AssertEqual(t, false, result)
 	})
 
 	t.Run("tool_requires_enablement_is_enabled", func(t *testing.T) {
 		_ = os.Unsetenv("DISABLED_TOOLS")
-		_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "q-developer-agent")
+		_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "kiro-agent")
 		registry.Init(logger)
 
 		// Tool requires enablement and is explicitly enabled
-		result := registry.ShouldRegisterTool("q-developer-agent")
+		result := registry.ShouldRegisterTool("kiro-agent")
 		testutils.AssertEqual(t, true, result)
 	})
 
 	t.Run("DISABLED_TOOLS_overrides_ENABLE_ADDITIONAL_TOOLS", func(t *testing.T) {
-		_ = os.Setenv("DISABLED_TOOLS", "q-developer-agent")
-		_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "q-developer-agent")
+		_ = os.Setenv("DISABLED_TOOLS", "kiro-agent")
+		_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "kiro-agent")
 		registry.Init(logger)
 
 		// DISABLED_TOOLS has highest priority
-		result := registry.ShouldRegisterTool("q-developer-agent")
+		result := registry.ShouldRegisterTool("kiro-agent")
 		testutils.AssertEqual(t, false, result)
 	})
 
 	t.Run("multiple_tools_in_ENABLE_ADDITIONAL_TOOLS", func(t *testing.T) {
 		_ = os.Unsetenv("DISABLED_TOOLS")
-		_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "q-developer-agent,claude-agent,gemini-agent")
+		_ = os.Setenv("ENABLE_ADDITIONAL_TOOLS", "kiro-agent,claude-agent,gemini-agent")
 		registry.Init(logger)
 
 		// All listed tools should be enabled
-		testutils.AssertEqual(t, true, registry.ShouldRegisterTool("q-developer-agent"))
+		testutils.AssertEqual(t, true, registry.ShouldRegisterTool("kiro-agent"))
 		testutils.AssertEqual(t, true, registry.ShouldRegisterTool("claude-agent"))
 		testutils.AssertEqual(t, true, registry.ShouldRegisterTool("gemini-agent"))
 


### PR DESCRIPTION
## Summary

Fix to ensure Kiro is not enabled by defalut

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Security fix

## Changes Made

- Added Kiro to additional tools

## Testing

- [x] I have tested my changes locally
- [ ] Tests pass (`make test`)
- [ ] Code lints successfully (`make lint`)
- [ ] Build completes without errors (`make build`)
- [ ] The changes never log to stdout/stderr when the server runs in stdio mode

## Documentation

- [ ] I have updated relevant documentation

## Related Issues

<!-- Fixes # -->

## Additional Notes

<!-- Any additional information, deployment notes, or considerations -->
