### PR TITLE
refactor: Add LDFlags to Github actions builds

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -121,7 +121,7 @@ jobs:
 
           # Build with ldflags to inject version info
           go build -v -o "bin/mcp-devtools" \
-            -ldflags "-X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
+            -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
             .
 
       - name: Upload build artifacts
@@ -194,7 +194,7 @@ jobs:
 
           # Build with ldflags to inject version info
           go build -v -o "bin/mcp-devtools" \
-            -ldflags "-X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
+            -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
             .
 
       - name: Upload build artifacts
@@ -270,7 +270,7 @@ jobs:
 
           # Build with ldflags to inject version info
           go build -v -o "bin/mcp-devtools" \
-            -ldflags "-X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
+            -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
             .
 
       - name: Upload build artifacts
@@ -351,7 +351,7 @@ jobs:
 
           # Build with ldflags to inject version info
           go build -v -o "bin/mcp-devtools.exe" \
-            -ldflags "-X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
+            -ldflags "-s -w -X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$BUILD_DATE" \
             .
 
       - name: Upload build artifacts


### PR DESCRIPTION
This pull request makes a small but important update to the Go build process in the GitHub Actions workflow. It adds the `-s -w` linker flags to all `go build` commands, which will strip debugging information from the binaries, resulting in smaller executable sizes.

Build process improvements:

* Added `-s -w` linker flags to all `go build` commands in `.github/workflows/build-and-release.yml` to reduce binary size by stripping debug information. [[1]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL124-R124) [[2]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL197-R197) [[3]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL273-R273) [[4]](diffhunk://#diff-20e0e050358c0425896e7b9edb659fec4ed949bb350a35841c0d616e1971cc6bL354-R354)