### PR TITLE
fix: Remove unused types and dead code from security package

### DIFF
--- a/internal/security/manager.go
+++ b/internal/security/manager.go
@@ -73,8 +73,7 @@ func NewSecurityManagerWithRules(rules *SecurityRules) (*SecurityManager, error)
 
 	// Create threat analyser
 	threatAnalyser := &ThreatAnalyser{
-		patterns:    make(map[string]PatternMatcher),
-		shellParser: &ShellParser{},
+		patterns: make(map[string]PatternMatcher),
 	}
 
 	// Create deny list checker
@@ -153,8 +152,7 @@ func NewSecurityManager() (*SecurityManager, error) {
 	// Create threat analyser
 	logrus.Debug("Creating threat analyser")
 	threatAnalyser := &ThreatAnalyser{
-		patterns:    make(map[string]PatternMatcher),
-		shellParser: &ShellParser{},
+		patterns: make(map[string]PatternMatcher),
 	}
 
 	// Create security advisor

--- a/internal/security/types.go
+++ b/internal/security/types.go
@@ -29,8 +29,7 @@ type SecurityAdvisor struct {
 
 // ThreatAnalyser performs Intent-Context-Destination analysis
 type ThreatAnalyser struct {
-	patterns    map[string]PatternMatcher
-	shellParser *ShellParser
+	patterns map[string]PatternMatcher
 }
 
 // SourceTrust manages domain trust scoring and categorisation
@@ -43,13 +42,11 @@ type SourceTrust struct {
 
 // YAMLRuleEngine manages YAML-based security rules
 type YAMLRuleEngine struct {
-	rules *SecurityRules
-	// patterns     *PatternLibrary // TODO: Implement pattern library
+	rules        *SecurityRules
 	compiled     map[string]PatternMatcher
 	rulesPath    string
 	lastModified time.Time
-	// watcher      *FileWatcher // TODO: Implement file watching
-	mutex sync.RWMutex
+	mutex        sync.RWMutex
 }
 
 // DenyListChecker enforces file and domain access controls
@@ -202,18 +199,3 @@ const (
 	ActionWarn  = "warn"
 	ActionBlock = "block"
 )
-
-// ShellParser handles shell command parsing
-type ShellParser struct {
-	// Implementation will use google/shlex
-}
-
-// FileWatcher monitors rule file changes
-type FileWatcher struct {
-	// Implementation will use fsnotify
-}
-
-// PatternLibrary holds reusable patterns
-type PatternLibrary struct {
-	Patterns map[string]string `yaml:"patterns"`
-}


### PR DESCRIPTION
Remove ShellParser, FileWatcher, and PatternLibrary types that were defined but never used. ShellParser had no methods and a stale comment referencing google/shlex, which is already called directly in analyser.go. FileWatcher was superseded by direct fsnotify usage in rules.go. PatternLibrary was only referenced in a comment.

Also removes the shellParser field from ThreatAnalyser and fixes struct field alignment in YAMLRuleEngine.

Fixes https://github.com/sammcj/mcp-devtools/pull/194