### PR TITLE
docs: fix duplicate word in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ mcp-devtools --transport http --port 18080 --oauth-enabled
 
 ### Environment Variables
 
-All environment variables are optional, but if you want to use specific search providers or document processing features, you may need to provide the the appropriate variables.
+All environment variables are optional, but if you want to use specific search providers or document processing features, you may need to provide the appropriate variables.
 
 **General:**
 


### PR DESCRIPTION
Removes a duplicated word in the README environment variables section: `the the` → `the`.

This is a documentation-only change.